### PR TITLE
Fix tests on Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'PyYAML',
         'pytz',
         'simplejson',
-        'six',
+        'six >= 1.11.0', # for the reference cycle fix in reraise()
         'ZODB',
         'zope.annotation',
         'zope.cachedescriptors',

--- a/src/nti/externalization/datastructures.py
+++ b/src/nti/externalization/datastructures.py
@@ -40,16 +40,16 @@ def _syntheticKeys():
 
 
 def _isMagicKey(key):
-    """ 
+    """
     For our mixin objects that have special keys, defines
-    those keys that are special and not settable by the user. 
+    those keys that are special and not settable by the user.
     """
     return key in _syntheticKeys()
 isSyntheticKey = _isMagicKey
 
 
 class ExternalizableDictionaryMixin(object):
-    """ 
+    """
     Implements a toExternalDictionary method as a base for subclasses.
     """
 
@@ -78,7 +78,7 @@ class ExternalizableDictionaryMixin(object):
                                                       **kwargs)
 
     def stripSyntheticKeysFromExternalDictionary(self, external):
-        """ 
+        """
         Given a mutable dictionary, removes all the external keys
         that might have been added by toExternalDictionary and echoed back.
         """
@@ -235,18 +235,18 @@ class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
 
         if      StandardExternalFields.CONTAINER_ID in parsed \
             and getattr(ext_self, StandardInternalFields.CONTAINER_ID, parsed) is None:
-            setattr(ext_self, 
+            setattr(ext_self,
                     StandardInternalFields.CONTAINER_ID,
                     parsed[StandardExternalFields.CONTAINER_ID])
         if      StandardExternalFields.CREATOR in parsed \
             and getattr(ext_self, StandardExternalFields.CREATOR, parsed) is None:
-            setattr(ext_self, 
+            setattr(ext_self,
                     StandardExternalFields.CREATOR,
                     parsed[StandardExternalFields.CREATOR])
         if (    StandardExternalFields.ID in parsed
             and getattr(ext_self, StandardInternalFields.ID, parsed) is None
             and self._ext_accept_external_id(ext_self, parsed)):
-            setattr(ext_self, 
+            setattr(ext_self,
                     StandardInternalFields.ID,
                     parsed[StandardExternalFields.ID])
 
@@ -368,7 +368,7 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
         # does show up in the profiling data
         cache = _InterfaceCache.cache_for(self, ext_self)
         if not cache.iface:
-            cache.iface = self._ext_find_schema(ext_self, 
+            cache.iface = self._ext_find_schema(ext_self,
                                                 iface_upper_bound or self._ext_iface_upper_bound)
         self._iface = cache.iface
 
@@ -382,7 +382,7 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
 
     @property
     def schema(self):
-        """ 
+        """
         The schema we will use to guide the process
         """
         return self._iface
@@ -460,10 +460,9 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
             try:
                 raise errors[0][1]
             except SchemaNotProvided as e:
-                exc_info = sys.exc_info()
                 if not e.args:  # zope.schema doesn't fill in the details, which sucks
                     e.args = (errors[0][0],)
-                raise exc_info[0], exc_info[1], exc_info[2]
+                raise
 
     def toExternalObject(self, mergeFrom=None, **kwargs):
         ext_class_name = None
@@ -472,7 +471,7 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
             if callable(ext_class_name):
                 # Even though the tagged value may have come from a superclass,
                 # give the actual class (interface) we're using
-                ext_class_name = ext_class_name(self._iface, 
+                ext_class_name = ext_class_name(self._iface,
                                                 self._ext_replacement())
             if ext_class_name:
                 break
@@ -526,7 +525,7 @@ class ModuleScopedInterfaceObjectIO(InterfaceObjectIO):
                                 "Searching module %s and considered %s on object %s of class %s and type %s"
                                 % (most_derived, iface, self._ext_search_module,
                                    list(self._ext_schemas_to_consider(ext_self)),
-                                   ext_self, ext_self.__class__, 
+                                   ext_self, ext_self.__class__,
                                    type(ext_self)))
 
         return most_derived

--- a/src/nti/externalization/externalization.py
+++ b/src/nti/externalization/externalization.py
@@ -8,12 +8,12 @@ Functions related to actually externalizing objects.
 from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
-logger = __import__('logging').getLogger(__name__)
-
-import six
 import numbers
 import collections
 from collections import defaultdict
+
+import six
+from six import iteritems
 
 from zope import component
 from zope import interface
@@ -47,6 +47,8 @@ from nti.externalization.interfaces import INonExternalizableReplacer
 from nti.externalization.interfaces import INonExternalizableReplacement
 
 from nti.externalization.oids import to_external_oid
+
+logger = __import__('logging').getLogger(__name__)
 
 # Local for speed
 StandardExternalFields_ID = StandardExternalFields.ID
@@ -151,7 +153,7 @@ class _ExternalizationState(object):
     registry = None
 
     def __init__(self, **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in iteritems(kwargs):
             setattr(self, k, v)
 
     @CachedProperty
@@ -316,7 +318,7 @@ def toExternalObject(obj,
                      decorate_callback=None,
                      default_non_externalizable_replacer=DefaultNonExternalizableReplacer,
                      **kwargs):
-    """ 
+    """
     Translates the object into a form suitable for
     external distribution, through some data formatting process. See :const:`SEQUENCE_TYPES`
     and :const:`MAPPING_TYPES` for details on what we can handle by default.
@@ -393,7 +395,7 @@ getExternals = get_externals
 
 def get_external_param(name, default=None):
     """
-    Return the currently value for an externalization param or default 
+    Return the currently value for an externalization param or default
     """
     try:
         return get_externals()[name]
@@ -403,9 +405,9 @@ getExternalParam = get_external_param
 
 
 def stripSyntheticKeysFromExternalDictionary(external):
-    """ 
+    """
     Given a mutable dictionary, removes all the external keys
-    that might have been added by :func:`to_standard_external_dictionary` and echoed back. 
+    that might have been added by :func:`to_standard_external_dictionary` and echoed back.
     """
     for key in _syntheticKeys():
         external.pop(key, None)
@@ -417,7 +419,7 @@ def _syntheticKeys():
 
 
 def _isMagicKey(key):
-    """ 
+    """
     For our mixin objects that have special keys, defines
     those keys that are special and not settable by the user.
     """

--- a/src/nti/externalization/singleton.py
+++ b/src/nti/externalization/singleton.py
@@ -27,6 +27,9 @@ class SingletonDecorator(type):
     A singleton class has only one instance which is returned every time the
     class is instantiated.
 
+    .. note:: We cannot be used with :func:`six.with_metaclass` because it introduces
+              temporary classes. You'll need to use the metaclass constructor directly.
+
     ** Developer notes **
             The class is instanciated immediately at the point where it is defined
             by calling cls.__new__(cls). This instance is cached and cls.__new__ is

--- a/src/nti/externalization/tests/test_singleton.py
+++ b/src/nti/externalization/tests/test_singleton.py
@@ -7,6 +7,8 @@ __docformat__ = "restructuredtext en"
 # disable: accessing protected members, too many methods
 # pylint: disable=W0212,R0904
 
+from six import with_metaclass
+
 from hamcrest import is_
 from hamcrest import assert_that
 from hamcrest import same_instance
@@ -20,8 +22,9 @@ class TestSingleton(ExternalizationLayerTest):
 
     def test_singleton_decorator(self):
 
-        class X(object):
-            __metaclass__ = SingletonDecorator
+        # Torturous way of getting a metaclass in a Py2/Py3 compatible
+        # way.
+        X = SingletonDecorator('X', (object,), {})
 
         # No context
         assert_that(X(), is_(same_instance(X())))


### PR DESCRIPTION
- Syntax fixes. Sometimes we were doing an unneeded `raise t, v, tb`, so stop doing that. Where we do need that, use `six.reraise`.
  Also delete the temporary variables to avoid reference cycles.
- Require a newer six for the same reason as above.
- d.iteritems -> six.iteritems(d)
- plistlib API changed
- A few places we were assuming `unicode` or `basestring`. One of them needs to be tightened on Python 2, left an `XXX` comment about that.

Fixes #17