### PR TITLE
Sort all the imports with isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,13 @@
+[settings]
+multi_line_output = 5
+# Do not allow grouped imports
+force_single_line = True
+line_length = 100
+forced_separate = hamcrest
+known_third_party = zope, hamcrest
+known_first_party = nti
+default_section = THIRDPARTY
+order_by_type = True
+atomic = True
+import_heading_stdlib = stdlib imports
+force_sort_within_sections = True

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     tests_require=TESTS_REQUIRE,
     install_requires=[
         'setuptools',
+        'Acquisition',
         'BTrees',
         'isodate',
         'nti.schema',
@@ -61,6 +62,7 @@ setup(
         'zope.cachedescriptors',
         'zope.component',
         'zope.configuration',
+        'zope.container',
         'zope.deferredimport',
         'zope.deprecation',
         'zope.dottedname',
@@ -73,6 +75,7 @@ setup(
         'zope.location',
         'zope.mimetype',
         'zope.preference',
+        'zope.proxy',
         'zope.schema',
         'zope.security',
     ],

--- a/src/nti/externalization/_compat.py
+++ b/src/nti/externalization/_compat.py
@@ -4,12 +4,16 @@
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
 
-import six
 
 if six.PY3:  # pragma: no cover
     def _unicode(s): return str(s)

--- a/src/nti/externalization/_pyramid.py
+++ b/src/nti/externalization/_pyramid.py
@@ -4,7 +4,10 @@
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)

--- a/src/nti/externalization/autopackage.py
+++ b/src/nti/externalization/autopackage.py
@@ -4,7 +4,18 @@
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from ZODB.loglevels import TRACE
+from zope import interface
+from zope.dottedname import resolve as dottedname
+from zope.mimetype.interfaces import IContentTypeAware
+
+from nti.externalization.datastructures import ModuleScopedInterfaceObjectIO
+from nti.externalization.internalization import register_legacy_search_module
+
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -14,17 +25,11 @@ logger = __import__('logging').getLogger(__name__)
 # is probably not what we want
 # import ExtensionClass
 
-from zope import interface
 
-from zope.dottedname import resolve as dottedname
 
-from zope.mimetype.interfaces import IContentTypeAware
 
-from ZODB.loglevels import TRACE
 
-from nti.externalization.datastructures import ModuleScopedInterfaceObjectIO
 
-from nti.externalization.internalization import register_legacy_search_module
 
 
 class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO):

--- a/src/nti/externalization/datastructures.py
+++ b/src/nti/externalization/datastructures.py
@@ -6,33 +6,30 @@ Datastructures to help externalization.
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-logger = __import__('logging').getLogger(__name__)
-
-import six
-import sys
+# stdlib imports
 import numbers
 
-from zope import schema
+from ZODB.POSException import POSError
+import six
 from zope import interface
-
+from zope import schema
+import zope.deferredimport
 from zope.schema.interfaces import SchemaNotProvided
 
-from ZODB.POSException import POSError
-
-from nti.externalization.externalization import toExternalObject
-from nti.externalization.externalization import to_standard_external_dictionary
 from nti.externalization.externalization import to_minimal_standard_external_dictionary
-
+from nti.externalization.externalization import to_standard_external_dictionary
+from nti.externalization.externalization import toExternalObject
 from nti.externalization.interfaces import IInternalObjectIO
-from nti.externalization.interfaces import StandardInternalFields
 from nti.externalization.interfaces import StandardExternalFields
-
+from nti.externalization.interfaces import StandardInternalFields
 from nti.externalization.internalization import validate_named_field_value
-
 from nti.schema.interfaces import find_most_derived_interface
+
+logger = __import__('logging').getLogger(__name__)
 
 
 def _syntheticKeys():
@@ -535,9 +532,7 @@ class ModuleScopedInterfaceObjectIO(InterfaceObjectIO):
                 if x.__module__ == self._ext_search_module.__name__
                 and not x.queryTaggedValue('_ext_is_marker_interface'))
 
-
 # Things that have moved
-import zope.deferredimport
 zope.deferredimport.initialize()
 zope.deferredimport.deprecatedFrom(
     "Moved to nti.externalization.interfaces",

--- a/src/nti/externalization/datetime.py
+++ b/src/nti/externalization/datetime.py
@@ -6,29 +6,27 @@ Support for reading and writing date and time related objects.
 See the :mod:`datetime` module, as well as the :mod:`zope.interface.common.idatetime`
 module for types of objects.
 
-.. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
+# stdlib imports
+from datetime import datetime
 import sys
 import time
-from datetime import datetime
 
 import isodate
 import pytz
 import six
-
 from zope import component
 from zope import interface
-
 from zope.interface.common.idatetime import IDate
 from zope.interface.common.idatetime import IDateTime
 from zope.interface.common.idatetime import ITimeDelta
 
 from nti.externalization.interfaces import IInternalObjectExternalizer
-
 from nti.schema.interfaces import InvalidValue
 
 

--- a/src/nti/externalization/dublincore.py
+++ b/src/nti/externalization/dublincore.py
@@ -11,20 +11,17 @@ of :mod:`zope.dublincore.interfaces`.
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
-
-logger = __import__('logging').getLogger(__name__)
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 from zope import component
 from zope import interface
-
-from zope.dublincore.interfaces import IDCExtended
 from zope.dublincore.interfaces import IDCDescriptiveProperties
+from zope.dublincore.interfaces import IDCExtended
 
-from nti.externalization.interfaces import StandardExternalFields
 from nti.externalization.interfaces import IExternalMappingDecorator
-
+from nti.externalization.interfaces import StandardExternalFields
 from nti.externalization.singleton import SingletonDecorator
 
 

--- a/src/nti/externalization/externalization.py
+++ b/src/nti/externalization/externalization.py
@@ -310,8 +310,7 @@ def toExternalObject(obj,
                      decorate=True,
                      useCache=True,
                      decorate_callback=None,
-                     default_non_externalizable_replacer=DefaultNonExternalizableReplacer,
-                     **kwargs):
+                     default_non_externalizable_replacer=DefaultNonExternalizableReplacer):
     """
     Translates the object into a form suitable for
     external distribution, through some data formatting process. See :const:`SEQUENCE_TYPES`
@@ -344,8 +343,7 @@ def toExternalObject(obj,
         return obj
 
     v = dict(locals())
-    v.pop('obj', None)
-    [v.pop(x, None) for x in kwargs]
+    v.pop('obj')
     state = _ExternalizationState(**v)
 
     if name is _NotGiven:
@@ -357,9 +355,7 @@ def toExternalObject(obj,
     if memos is None:
         memos = defaultdict(dict)
 
-    data = dict(kwargs)
-    data.update({'name': name, 'memos': memos})
-    _manager.push(data)
+    _manager.push({'name': name, 'memos': memos})
 
     state.name = name
     state.memo = memos[name]
@@ -376,26 +372,6 @@ def toExternalObject(obj,
         _manager.pop()
 to_external_object = toExternalObject
 
-
-def get_externals():
-    """
-    Return the externalization params
-    """
-    state = dict(_manager.get())
-    [state.pop(x, None) for x in ('request', 'registry', 'name', 'memos')]
-    return state
-getExternals = get_externals
-
-
-def get_external_param(name, default=None):
-    """
-    Return the currently value for an externalization param or default
-    """
-    try:
-        return get_externals()[name]
-    except KeyError:
-        return default
-getExternalParam = get_external_param
 
 
 def stripSyntheticKeysFromExternalDictionary(external):

--- a/src/nti/externalization/externalization.py
+++ b/src/nti/externalization/externalization.py
@@ -5,48 +5,46 @@ Functions related to actually externalizing objects.
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-import numbers
+# stdlib imports
+from calendar import timegm as _calendar_gmtime
 import collections
 from collections import defaultdict
+import numbers
 
+import BTrees.OOBTree
+from ZODB.POSException import POSKeyError
+import persistent
 import six
 from six import iteritems
-
 from zope import component
-from zope import interface
 from zope import deprecation
-
-from zope.hookable import hookable
-
-from zope.interface.common.sequence import IFiniteSequence
-
+from zope import interface
+from zope.cachedescriptors.property import CachedProperty
+import zope.deferredimport
 from zope.dublincore.interfaces import IDCTimes
-
+from zope.hookable import hookable
+from zope.interface.common.sequence import IFiniteSequence
 from zope.security.interfaces import IPrincipal
 from zope.security.management import system_user
 
-from ZODB.POSException import POSKeyError
-
-import persistent
-
-import BTrees.OOBTree
-
 from nti.externalization._compat import to_unicode
-
+from nti.externalization._pyramid import ThreadLocalManager
+from nti.externalization._pyramid import get_current_request
+from nti.externalization.interfaces import IExternalMappingDecorator
 from nti.externalization.interfaces import IExternalObject
+from nti.externalization.interfaces import IExternalObjectDecorator
+from nti.externalization.interfaces import ILocatedExternalSequence
+from nti.externalization.interfaces import INonExternalizableReplacement
+from nti.externalization.interfaces import INonExternalizableReplacer
 from nti.externalization.interfaces import LocatedExternalDict
 from nti.externalization.interfaces import StandardExternalFields
 from nti.externalization.interfaces import StandardInternalFields
-from nti.externalization.interfaces import IExternalObjectDecorator
-from nti.externalization.interfaces import ILocatedExternalSequence
-from nti.externalization.interfaces import IExternalMappingDecorator
-from nti.externalization.interfaces import INonExternalizableReplacer
-from nti.externalization.interfaces import INonExternalizableReplacement
-
 from nti.externalization.oids import to_external_oid
+
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -81,7 +79,6 @@ def is_system_user(obj):
 # the name that was established at the top level.
 _NotGiven = object()
 
-from nti.externalization._pyramid import ThreadLocalManager
 
 _manager = ThreadLocalManager(default=lambda: {'name': _NotGiven, 'memos': None})
 
@@ -143,7 +140,6 @@ MAPPING_TYPES = (persistent.mapping.PersistentMapping,
                  BTrees.OOBTree.OOBTree,
                  collections.Mapping)
 
-from zope.cachedescriptors.property import CachedProperty
 
 
 class _ExternalizationState(object):
@@ -397,7 +393,6 @@ def _isMagicKey(key):
 isSyntheticKey = _isMagicKey
 
 
-from calendar import timegm as _calendar_gmtime
 
 
 def datetime_to_epoch(dt):
@@ -500,7 +495,6 @@ def _ext_class_if_needed(self, result):
         result[StandardExternalFields_CLASS] = self.__class__.__name__
 
 
-from nti.externalization._pyramid import get_current_request
 
 
 def setExternalIdentifiers(self, result):
@@ -638,9 +632,8 @@ def removed_unserializable(ext):
     _clean(ext)
     return ext
 
-
 # Things that have moved
-import zope.deferredimport
+
 zope.deferredimport.initialize()
 zope.deferredimport.deprecatedFrom(
     "Import from .persistence",

--- a/src/nti/externalization/integer_strings.py
+++ b/src/nti/externalization/integer_strings.py
@@ -24,13 +24,16 @@ this algorithm gracefully but still honor codes in the wild.
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-logger = __import__('logging').getLogger(__name__)
+# stdlib imports
+import string
 
 import six
-import string
+
+
 try:
     from string import maketrans
     from string import translate

--- a/src/nti/externalization/interfaces.py
+++ b/src/nti/externalization/interfaces.py
@@ -5,23 +5,19 @@ Externalization Interfaces
 
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 from zope import interface
-
 from zope.component.interfaces import IFactory
-
 from zope.interface.common.mapping import IFullMapping
 from zope.interface.common.sequence import ISequence
-
-from zope.location import ILocation
-
-from zope.interface.interfaces import ObjectEvent
 from zope.interface.interfaces import IObjectEvent
-
-from zope.lifecycleevent import ObjectModifiedEvent
+from zope.interface.interfaces import ObjectEvent
 from zope.lifecycleevent import IObjectModifiedEvent
+from zope.lifecycleevent import ObjectModifiedEvent
+from zope.location import ILocation
 
 
 # pylint:disable=inherit-non-class,no-method-argument,no-self-argument

--- a/src/nti/externalization/internalization.py
+++ b/src/nti/externalization/internalization.py
@@ -4,46 +4,42 @@
 Functions for taking externalized objects and creating application
 model objects.
 
-.. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-import sys
+# stdlib imports
+import collections
 import inspect
 import numbers
-import collections
-
-import six
-from six import reraise
-
-from zope import component
-from zope import interface
-
-from zope.dottedname.resolve import resolve
-
-from zope.event import notify as _zope_event_notify
-
-from zope.lifecycleevent import Attributes
-
-from zope.schema.interfaces import IField
-from zope.schema.interfaces import WrongType
-from zope.schema.interfaces import IFromUnicode
-from zope.schema.interfaces import ValidationError
-from zope.schema.interfaces import SchemaNotProvided
-from zope.schema.interfaces import WrongContainedType
+import sys
 
 from persistent.interfaces import IPersistent
+import six
+from six import reraise
+from zope import component
+from zope import interface
+from zope.dottedname.resolve import resolve
+from zope.event import notify as _zope_event_notify
+from zope.lifecycleevent import Attributes
+from zope.schema.interfaces import IField
+from zope.schema.interfaces import IFromUnicode
+from zope.schema.interfaces import SchemaNotProvided
+from zope.schema.interfaces import ValidationError
+from zope.schema.interfaces import WrongContainedType
+from zope.schema.interfaces import WrongType
 
-from nti.externalization.interfaces import IFactory
-from nti.externalization.interfaces import IMimeObjectFactory
 from nti.externalization.interfaces import IClassObjectFactory
-from nti.externalization.interfaces import IInternalObjectUpdater
-from nti.externalization.interfaces import StandardExternalFields
-from nti.externalization.interfaces import IExternalReferenceResolver
-from nti.externalization.interfaces import ObjectModifiedFromExternalEvent
 from nti.externalization.interfaces import IExternalizedObjectFactoryFinder
+from nti.externalization.interfaces import IExternalReferenceResolver
+from nti.externalization.interfaces import IFactory
+from nti.externalization.interfaces import IInternalObjectUpdater
+from nti.externalization.interfaces import IMimeObjectFactory
+from nti.externalization.interfaces import ObjectModifiedFromExternalEvent
+from nti.externalization.interfaces import StandardExternalFields
+
 
 logger = __import__('logging').getLogger(__name__)
 

--- a/src/nti/externalization/oids.py
+++ b/src/nti/externalization/oids.py
@@ -2,30 +2,26 @@
 # -*- coding: utf-8 -*-
 """
 Functions for externalizing OIDs.
-
-.. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-logger = __import__('logging').getLogger(__name__)
-
+# stdlib imports
 import binascii
 import collections
 
-from zope import component
-
-from zope.intid.interfaces import IIntIds
-
+# Things that have moved
 from ZODB.interfaces import IConnection
+from zope import component
+import zope.deferredimport
+from zope.intid.interfaces import IIntIds
 
 from nti.externalization._compat import bytes_
 from nti.externalization._compat import native_
-
-from nti.externalization.integer_strings import to_external_string
 from nti.externalization.integer_strings import from_external_string
-
+from nti.externalization.integer_strings import to_external_string
 from nti.externalization.proxy import removeAllProxies
 
 
@@ -164,8 +160,6 @@ def fromExternalOID(ext_oid):
 from_external_oid = fromExternalOID
 
 
-# Things that have moved
-import zope.deferredimport
 zope.deferredimport.initialize()
 zope.deferredimport.deprecatedFrom(
     "Import from nti.ntiids.oids",

--- a/src/nti/externalization/persistence.py
+++ b/src/nti/externalization/persistence.py
@@ -2,37 +2,26 @@
 # -*- coding: utf-8 -*-
 """
 Classes and functions for dealing with persistence in an external context.
-
-.. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-logger = __import__('logging').getLogger(__name__)
-
+# stdlib imports
 import collections
 
+import persistent
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
+from persistent.wref import WeakRef as PWeakRef
 from zope import interface
 
-import persistent
-
-from persistent.list import PersistentList
-
-from persistent.mapping import PersistentMapping
-
-from persistent.wref import WeakRef as PWeakRef
-
 from nti.externalization.datastructures import ExternalizableDictionaryMixin
-
 from nti.externalization.externalization import toExternalObject
-
 from nti.externalization.interfaces import IExternalObject
-
 from nti.externalization.oids import toExternalOID
-
 from nti.externalization.proxy import removeAllProxies
-
 from nti.zodb.persistentproperty import PersistentPropertyHolder
 
 # disable: accessing protected members
@@ -85,8 +74,8 @@ def getPersistentState(obj):
 
 
 def setPersistentStateChanged(obj):
-    """ 
-    Explicitly marks a persistent object as changed. 
+    """
+    Explicitly marks a persistent object as changed.
     """
     try:
         obj._p_changed = True

--- a/src/nti/externalization/proxy.py
+++ b/src/nti/externalization/proxy.py
@@ -6,31 +6,19 @@ Utilities for working with various kinds of transparent proxies.
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-logger = __import__('logging').getLogger(__name__)
+import Acquisition
+import zope.container.contained
+import zope.proxy
 
 _unwrappers = []
-try:
-    import zope.proxy
-    _unwrappers.append(zope.proxy.removeAllProxies)
-except ImportError:
-    pass
-
-try:
-    import zope.container.contained
-    _unwrappers.append(zope.container.contained.getProxiedObject)
-except ImportError:
-    pass
-
-try:
-    import Acquisition
-    aq_base = getattr(Acquisition, 'aq_base')
-    _unwrappers.append(aq_base)
-except (ImportError, AttributeError):
-    pass
-
+_unwrappers.append(zope.proxy.removeAllProxies)
+_unwrappers.append(zope.container.contained.getProxiedObject)
+#aq_base = getattr(Acquisition, 'aq_base')
+_unwrappers.append(Acquisition.aq_base)
 
 def removeAllProxies(proxy):
     """

--- a/src/nti/externalization/representation.py
+++ b/src/nti/externalization/representation.py
@@ -5,23 +5,24 @@ External representation support.
 
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-
+from ZODB.POSException import ConnectionStateError
+import simplejson
+import yaml
 from zope import component
 from zope import interface
 
 from nti.externalization._compat import to_unicode
-
+from nti.externalization.externalization import _NotGiven
+from nti.externalization.externalization import toExternalObject
 from nti.externalization.interfaces import EXT_REPR_JSON
 from nti.externalization.interfaces import EXT_REPR_YAML
-
 from nti.externalization.interfaces import IExternalObjectIO
 from nti.externalization.interfaces import IExternalObjectRepresenter
 
-from nti.externalization.externalization import _NotGiven
-from nti.externalization.externalization import toExternalObject
 
 # Driver functions
 
@@ -55,7 +56,6 @@ def to_json_representation(obj):
 # JSON
 
 
-import simplejson
 
 
 def _second_pass_to_external_object(obj):
@@ -114,9 +114,6 @@ to_json_representation_externalized = JsonRepresenter().dump
 
 # YAML
 
-import yaml
-
-
 class _ExtDumper(yaml.SafeDumper):  # pylint:disable=R0904
     """
     We want to represent all of our special object types,
@@ -156,9 +153,6 @@ class YamlRepresenter(object):
 
 
 # Misc
-
-
-from ZODB.POSException import ConnectionStateError
 
 
 def make_repr(default=lambda self: "%s().__dict__.update( %s )" % (self.__class__.__name__, self.__dict__)):

--- a/src/nti/externalization/singleton.py
+++ b/src/nti/externalization/singleton.py
@@ -2,14 +2,11 @@
 # -*- coding: utf-8 -*-
 """
 Support for singleton objects that are used as external object decorators.
-
-.. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
-
-logger = __import__('logging').getLogger(__name__)
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 # This was originally based on code from sympy.core.singleton
 

--- a/src/nti/externalization/tests/test_datastructures.py
+++ b/src/nti/externalization/tests/test_datastructures.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-# disable: accessing protected members, too many methods
-# pylint: disable=W0212,R0904
-
-from hamcrest import assert_that
-from hamcrest import has_property
-
+# stdlib imports
 import sys
 
 from zope import interface
 
 from nti.externalization.datastructures import ModuleScopedInterfaceObjectIO
-
 from nti.externalization.tests import ExternalizationLayerTest
+
+from hamcrest import assert_that
+from hamcrest import has_property
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
 
 
 class TestDatastructures(ExternalizationLayerTest):

--- a/src/nti/externalization/tests/test_datetime.py
+++ b/src/nti/externalization/tests/test_datetime.py
@@ -1,34 +1,34 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-# disable: accessing protected members, too many methods
-# pylint: disable=W0212,R0904
-
-from hamcrest import is_
-from hamcrest import none
-from hamcrest import raises
-from hamcrest import calling
-from hamcrest import assert_that
-from hamcrest import has_property
-
-import os
-import time
+# stdlib imports
 from datetime import date
 from datetime import timedelta
+import os
+import time
 
 from zope.interface.common.idatetime import IDate
 from zope.interface.common.idatetime import IDateTime
 
 from nti.externalization.datetime import _datetime_to_string
 from nti.externalization.datetime import datetime_from_string
-
+from nti.externalization.tests import ExternalizationLayerTest
+from nti.externalization.tests import externalizes
 from nti.schema.interfaces import InvalidValue
 
-from nti.externalization.tests import externalizes
-from nti.externalization.tests import ExternalizationLayerTest
+from hamcrest import assert_that
+from hamcrest import calling
+from hamcrest import has_property
+from hamcrest import is_
+from hamcrest import none
+from hamcrest import raises
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
 
 
 class TestDatetime(ExternalizationLayerTest):

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -43,12 +43,9 @@ from ZODB.broken import Broken
 from nti.externalization.datastructures import ExternalizableInstanceDict
 from nti.externalization.datastructures import ExternalizableDictionaryMixin
 
-
-from nti.externalization.externalization import _manager
 from nti.externalization.externalization import _DevmodeNonExternalizableObjectReplacer
 
 from nti.externalization.externalization import toExternalObject
-from nti.externalization.externalization import get_external_param
 from nti.externalization.externalization import catch_replace_action
 from nti.externalization.externalization import removed_unserializable
 from nti.externalization.externalization import set_external_identifiers
@@ -220,16 +217,6 @@ class TestFunctions(ExternalizationLayerTest):
         assert_that(ext, has_entry('a', is_([3, 4])))
         assert_that(ext, has_entry('z', is_(none())))
         assert_that(ext, has_entry('b', has_entry('c', is_([None, 1]))))
-
-    def test_get_external_param(self):
-        _manager.push({'foo': 'var'})
-        try:
-            value = get_external_param('foo')
-            assert_that(value, is_('var'))
-            value = get_external_param('unknown')
-            assert_that(value, is_(none()))
-        finally:
-            _manager.pop()
 
 
 class TestPersistentExternalizableWeakList(unittest.TestCase):

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -1,31 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-# disable: accessing protected members, too many methods
-# pylint: disable=W0212,R0904
-
-from hamcrest import is_
-from hamcrest import none
-from hamcrest import is_not
-from hamcrest import raises
-from hamcrest import calling
-from hamcrest import has_key
-from hamcrest import contains
-from hamcrest import has_entry
-from hamcrest import has_items
-from hamcrest import assert_that
-from hamcrest import same_instance
-from hamcrest import has_property as has_attr
-does_not = is_not
-
-from nti.testing.matchers import verifiably_provides
-
-import sys
+# stdlib imports
+import datetime
 import json
-
+from numbers import Number
+import sys
 import unittest
 
 try:
@@ -33,40 +17,56 @@ try:
 except ImportError:
     from collections import UserDict
 
-import persistent
-
-from zope import component
-from zope import interface
 
 from ZODB.broken import Broken
+import persistent
+from zope import component
+from zope import interface
+from zope.dublincore import interfaces as dub_interfaces
 
-from nti.externalization.datastructures import ExternalizableInstanceDict
 from nti.externalization.datastructures import ExternalizableDictionaryMixin
-
+from nti.externalization.datastructures import ExternalizableInstanceDict
 from nti.externalization.externalization import _DevmodeNonExternalizableObjectReplacer
-
-from nti.externalization.externalization import toExternalObject
 from nti.externalization.externalization import catch_replace_action
 from nti.externalization.externalization import removed_unserializable
 from nti.externalization.externalization import set_external_identifiers
 from nti.externalization.externalization import to_standard_external_dictionary
-
-from nti.externalization.interfaces import EXT_REPR_YAML
+from nti.externalization.externalization import toExternalObject
 from nti.externalization.interfaces import EXT_REPR_JSON
-from nti.externalization.interfaces import LocatedExternalList
+from nti.externalization.interfaces import EXT_REPR_YAML
+from nti.externalization.interfaces import IExternalObject
+from nti.externalization.interfaces import IExternalObjectDecorator
 from nti.externalization.interfaces import LocatedExternalDict
-
+from nti.externalization.interfaces import LocatedExternalList
+from nti.externalization.interfaces import StandardExternalFields
 from nti.externalization.internalization import _search_for_external_factory
-
-from nti.externalization.oids import toExternalOID
 from nti.externalization.oids import fromExternalOID
-
-from nti.externalization.persistence import getPersistentState
+from nti.externalization.oids import toExternalOID
+from nti.externalization.persistence import NoPickle
 from nti.externalization.persistence import PersistentExternalizableWeakList
-
+from nti.externalization.persistence import getPersistentState
 from nti.externalization.representation import to_external_representation
-
 from nti.externalization.tests import ExternalizationLayerTest
+from nti.externalization.tests import assert_does_not_pickle
+from nti.testing.matchers import verifiably_provides
+
+from hamcrest import assert_that
+from hamcrest import calling
+from hamcrest import contains
+from hamcrest import has_entry
+from hamcrest import has_items
+from hamcrest import has_key
+from hamcrest import is_
+from hamcrest import is_not
+from hamcrest import none
+from hamcrest import raises
+from hamcrest import same_instance
+from hamcrest import has_property as has_attr
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
+
+does_not = is_not
 
 
 class TestFunctions(ExternalizationLayerTest):
@@ -286,14 +286,8 @@ class TestExternalizableInstanceDict(ExternalizationLayerTest):
         assert_that(newObj.A2, is_("2"))
 
 
-import datetime
-from numbers import Number
 
-from zope.dublincore import interfaces as dub_interfaces
 
-from nti.externalization.interfaces import IExternalObject
-from nti.externalization.interfaces import StandardExternalFields
-from nti.externalization.interfaces import IExternalObjectDecorator
 
 
 class TestToExternalObject(ExternalizationLayerTest):
@@ -399,9 +393,7 @@ class TestToExternalObject(ExternalizationLayerTest):
                     has_entry(StandardExternalFields.CREATED_TIME, is_(Number)))
 
 
-from nti.externalization.persistence import NoPickle
 
-from nti.externalization.tests import assert_does_not_pickle
 
 
 @NoPickle

--- a/src/nti/externalization/tests/test_integer_strings.py
+++ b/src/nti/externalization/tests/test_integer_strings.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
-# disable: accessing protected members, too many methods
-# pylint: disable=W0212,R0904
-
-from hamcrest import is_
-from hamcrest import assert_that
-
+# stdlib imports
 import sys
 import unittest
 
-from nti.externalization.integer_strings import to_external_string
 from nti.externalization.integer_strings import from_external_string
+from nti.externalization.integer_strings import to_external_string
+
+from hamcrest import assert_that
+from hamcrest import is_
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
 
 try:
     maxint = sys.maxint
@@ -45,5 +47,5 @@ class TestIntStrings(unittest.TestCase):
             _t(i)
 
     def test_decode_unicode(self):
-        assert_that(from_external_string(u'abcde'), 
+        assert_that(from_external_string(u'abcde'),
 					is_(204869188))

--- a/src/nti/externalization/tests/test_internalization.py
+++ b/src/nti/externalization/tests/test_internalization.py
@@ -1,21 +1,27 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope.interface.common.idatetime import IDate
+
+from nti.externalization.tests import ExternalizationLayerTest
+from nti.schema.interfaces import InvalidValue
+
+from hamcrest import assert_that
+from hamcrest import calling
+from hamcrest import raises
+
 __docformat__ = "restructuredtext en"
 
 # disable: accessing protected members, too many methods
 # pylint: disable=W0212,R0904
 
-from hamcrest import raises
-from hamcrest import calling
-from hamcrest import assert_that
 
-from zope.interface.common.idatetime import IDate
 
-from nti.schema.interfaces import InvalidValue
 
-from nti.externalization.tests import ExternalizationLayerTest
 
 class TestDate(ExternalizationLayerTest):
 

--- a/src/nti/externalization/tests/test_persistence.py
+++ b/src/nti/externalization/tests/test_persistence.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
-
-# disable: accessing protected members, too many methods
-# pylint: disable=W0212,R0904
-
-from hamcrest import is_
-from hamcrest import is_not
-from hamcrest import raises
-from hamcrest import calling
-from hamcrest import assert_that
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 from persistent import Persistent
 
 from nti.externalization.persistence import PersistentExternalizableList
 from nti.externalization.persistence import PersistentExternalizableWeakList
-
 from nti.externalization.tests import ExternalizationLayerTest
+
+from hamcrest import assert_that
+from hamcrest import calling
+from hamcrest import is_
+from hamcrest import is_not
+from hamcrest import raises
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
 
 
 class TestPersistentExternalizableList(ExternalizationLayerTest):
@@ -68,7 +68,7 @@ class TestPersistentExternalizableWeakList(ExternalizationLayerTest):
 
         obj.append(pers2)
         # mul
-        assert_that(obj * 2, 
+        assert_that(obj * 2,
                     is_(PersistentExternalizableWeakList([pers2, pers2])))
 
         # imul

--- a/src/nti/externalization/tests/test_proxy.py
+++ b/src/nti/externalization/tests/test_proxy.py
@@ -1,57 +1,40 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# stdlib imports
+import unittest
+
+from Acquisition import Implicit
+from ExtensionClass import Base
+from zope.container.contained import ContainedProxy
+from zope.proxy import ProxyBase
+
+from nti.externalization.proxy import removeAllProxies
+from nti.testing.matchers import aq_inContextOf
+
+from hamcrest import assert_that
+from hamcrest import is_
+from hamcrest import same_instance
 
 # disable: accessing protected members, too many methods
 # pylint: disable=W0212,R0904
 
-from hamcrest import is_
-from hamcrest import assert_that
-from hamcrest import same_instance
 
-from nti.testing.matchers import aq_inContextOf
+class EC(Base):
+    x = None
 
-import unittest
+class IM(Implicit):
+    pass
 
-try:
-    from zope.proxy import ProxyBase
-except ImportError:
-    def ProxyBase(x): return x
-
-try:
-    from zope.container.contained import ContainedProxy
-except ImportError:
-    def ContainedProxy(x): return x
-
-try:
-    from Acquisition import Implicit
-    from ExtensionClass import Base
-
-    class EC(Base):
-        x = None
-
-    class IM(Implicit):
-        pass
-
-    def aq_proxied(im):
-        ec = EC()
-        ec.x = im
-        assert_that(ec.x, is_(aq_inContextOf(ec)))
-        return ec.x
-
-except ImportError:
-    EC = None
-
-    class IM(object):
-        pass
-
-    def aq_proxied():
-        return IM()
-
-from nti.externalization.proxy import removeAllProxies
-
+def aq_proxied(im):
+    ec = EC()
+    ec.x = im
+    assert_that(ec.x, is_(aq_inContextOf(ec)))
+    return ec.x
 
 class TestProxy(unittest.TestCase):
 

--- a/src/nti/externalization/tests/test_singleton.py
+++ b/src/nti/externalization/tests/test_singleton.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from nti.externalization.singleton import SingletonDecorator
+from nti.externalization.tests import ExternalizationLayerTest
+
+from hamcrest import assert_that
+from hamcrest import is_
+from hamcrest import same_instance
 
 # disable: accessing protected members, too many methods
 # pylint: disable=W0212,R0904
-
-from six import with_metaclass
-
-from hamcrest import is_
-from hamcrest import assert_that
-from hamcrest import same_instance
-
-from nti.externalization.singleton import SingletonDecorator
-
-from nti.externalization.tests import ExternalizationLayerTest
 
 
 class TestSingleton(ExternalizationLayerTest):

--- a/src/nti/externalization/zcml.py
+++ b/src/nti/externalization/zcml.py
@@ -7,26 +7,32 @@ for mime types.
 .. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from ZODB import loglevels
+from ZODB.POSException import POSError
+from zope import interface
+from zope.component import zcml as component_zcml
+from zope.component.factory import Factory
+from zope.configuration.fields import GlobalInterface
+from zope.configuration.fields import GlobalObject
+from zope.configuration.fields import Tokens
+
+from nti.externalization.autopackage import AutoPackageSearchingScopedInterfaceObjectIO
+from nti.externalization.interfaces import IMimeObjectFactory
+
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
 
-from zope import interface
 
-from zope.component import zcml as component_zcml
 
-from zope.component.factory import Factory
 
-from zope.configuration.fields import Tokens
-from zope.configuration.fields import GlobalObject
-from zope.configuration.fields import GlobalInterface
 
-from ZODB import loglevels
 
-from ZODB.POSException import POSError
 
-from nti.externalization.interfaces import IMimeObjectFactory
 
 
 @interface.implementer(IMimeObjectFactory)
@@ -126,7 +132,6 @@ class IAutoPackageExternalizationDirective(interface.Interface):
                           required=False)
 
 
-from nti.externalization.autopackage import AutoPackageSearchingScopedInterfaceObjectIO
 
 
 def autoPackageExternalization(_context, root_interfaces, modules, factory_modules=None, iobase=None):


### PR DESCRIPTION
This eliminates a bunch of pylint warnings, making the remaining ones more useful.

Also eliminate `__docformat__` in touched files because restructuredtext is now the default.

Also eliminate logger declarations in files that aren't using them. That should speed up startup and reduce memory usage by a tiny bit.

Currently based on #25, only the tip commit is relevant.