### PR TITLE
Pre-emptively convert the creator to a string like we used to

### DIFF
--- a/src/nti/externalization/_compat.py
+++ b/src/nti/externalization/_compat.py
@@ -8,12 +8,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six import text_type
 
 def to_unicode(s, encoding='utf-8', err='strict'):
     """
     Decode a byte sequence and unicode result
     """
-    return s.decode(encoding, err) if isinstance(s, bytes) else s
+    if not isinstance(s, text_type) and s is not None:
+        s = s.decode(encoding, err)
+    return s
 
 text_ = to_unicode
 

--- a/src/nti/externalization/externalization.py
+++ b/src/nti/externalization/externalization.py
@@ -147,16 +147,16 @@ class _ExternalizationState(object):
     name = u''
     request = None
     registry = None
+    # We take a similar approach to pickle.Pickler
+    # for memoizing objects we've seen:
+    # we map the id of an object to a two tuple: (obj, external-value)
+    # the original object is kept in the tuple to keep transient objects alive
+    # and thus ensure no overlapping ids
+    memo = None
 
-    def __init__(self, kwargs):
-        # We take a similar approach to pickle.Pickler
-        # for memoizing objects we've seen:
-        # we map the id of an object to a two tuple: (obj, external-value)
-        # the original object is kept in the tuple to keep transient objects alive
-        # and thus ensure no overlapping ids
-        self.memo = {}
-        # Allow it to be passed as a kwarg to override
+    def __init__(self, memos, kwargs):
         self.__dict__.update(kwargs)
+        self.memo = memos[self.name]
 
 class _RecursiveCallState(dict):
     pass
@@ -170,11 +170,11 @@ def _to_external_object_state(obj, state, top_level=False, decorate=True,
     __traceback_info__ = obj
 
     orig_obj = obj
-    orig_obj_id = id(obj)
+    orig_obj_id = id(obj) # XXX: Relatively expensive on PyPy
     if useCache:
         value = state.memo.get(orig_obj_id, None)
         result = value[1] if value is not None else None
-        if result is None:  # mark
+        if result is None:  # mark as in progress
             state.memo[orig_obj_id] = (orig_obj, _marker)
         elif result is not _marker:
             return result
@@ -337,27 +337,23 @@ def toExternalObject(obj,
     if isinstance(obj, _primitives):
         return obj
 
-    v = dict(locals())
-    v.pop('obj')
-    state = _ExternalizationState(v)
-
     if name is _NotGiven:
         name = _manager.get()['name']
     if name is _NotGiven:
         name = ''
+    if request is _NotGiven:
+        request = get_current_request()
 
     memos = _manager.get()['memos']
     if memos is None:
         memos = defaultdict(dict)
 
+    v = dict(locals())
+    v.pop('obj')
+    v.pop("memos")
+    state = _ExternalizationState(memos, v)
+
     _manager.push({'name': name, 'memos': memos})
-
-    state.name = name
-    state.memo = memos[name]
-
-    if request is _NotGiven:
-        request = get_current_request()
-    state.request = request
 
     try:
         return _to_external_object_state(obj, state, top_level=True,


### PR DESCRIPTION
Be explicit about this.

Test this and other recursion scenarios.