### PR TITLE
Deprecate register_legacy_search_module and friends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,3 +15,6 @@
   functions. Move the Pyramid integration there (and deprecate that).
   Also move the NTIID support there (but the old name works too).
   See https://github.com/NextThought/nti.externalization/issues/27
+- Deprecate
+  ``nti.externalization.internalization.register_legacy_search_module``.
+  See https://github.com/NextThought/nti.externalization/issues/35

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'zope.configuration',
         'zope.container',
         'zope.deferredimport',
-        'zope.deprecation',
+        'zope.deprecation >= 4.3.0',
         'zope.dottedname',
         'zope.dublincore',
         'zope.event',

--- a/src/nti/externalization/autopackage.py
+++ b/src/nti/externalization/autopackage.py
@@ -11,11 +11,13 @@ from __future__ import print_function
 
 from ZODB.loglevels import TRACE
 from zope import interface
+from zope.deprecation import Suppressor
 from zope.dottedname import resolve as dottedname
 from zope.mimetype.interfaces import IContentTypeAware
 
 from nti.externalization.datastructures import ModuleScopedInterfaceObjectIO
-from nti.externalization.internalization import register_legacy_search_module
+with Suppressor(): # XXX: Temporary
+    from nti.externalization.internalization import register_legacy_search_module
 
 logger = __import__('logging').getLogger(__name__)
 

--- a/src/nti/externalization/autopackage.py
+++ b/src/nti/externalization/autopackage.py
@@ -27,6 +27,9 @@ logger = __import__('logging').getLogger(__name__)
 # import ExtensionClass
 
 
+class _ClassNameRegistry(object):
+    __name__ = ''
+
 class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO):
     """
     A special, magic, type of interface-driven input and output, one designed
@@ -139,8 +142,8 @@ class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO)
         :class:`zope.mimetype.interfaces.IContentTypeAware`.
         """
 
-        class _ClassNameRegistry(object):
-            pass
+        registry = _ClassNameRegistry()
+        registry.__name__ = package_name
 
         for mod_name in cls._ap_enumerate_module_names():
             mod = dottedname.resolve(package_name + '.' + mod_name)
@@ -150,8 +153,8 @@ class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO)
                 if getattr(v, '__module__', None) != mod.__name__ \
                     or not issubclass(type(v), type):
                     continue
-                cls._ap_handle_one_potential_factory_class(_ClassNameRegistry, package_name, v)
-        return _ClassNameRegistry
+                cls._ap_handle_one_potential_factory_class(registry, package_name, v)
+        return registry
 
     @classmethod
     def _ap_handle_one_potential_factory_class(cls, namespace, package_name, implementation_class):
@@ -271,3 +274,5 @@ class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO)
         # XXX: Return this instead of setting it now so that the ZCML
         # directive has more control.
         register_legacy_search_module(factories)
+
+        return factories

--- a/src/nti/externalization/internalization.py
+++ b/src/nti/externalization/internalization.py
@@ -24,6 +24,7 @@ from six import reraise
 from six import iteritems
 from zope import component
 from zope import interface
+from zope.deprecation import deprecated
 from zope.dottedname.resolve import resolve
 from zope.event import notify as _zope_event_notify
 from zope.lifecycleevent import Attributes
@@ -79,6 +80,12 @@ def register_legacy_search_module(module_name):
     if module_name:
         LEGACY_FACTORY_SEARCH_MODULES.add(module_name)
 
+
+deprecated('register_legacy_search_module',
+           "Legacy search modules are deprecated. Prefer to register "
+           "explicit mime or class factories. See "
+           "https://github.com/NextThought/nti.externalization/issues/35",
+           cls=FutureWarning)
 
 _EMPTY_DICT = {}
 

--- a/src/nti/externalization/internalization.py
+++ b/src/nti/externalization/internalization.py
@@ -50,7 +50,9 @@ from nti.externalization.interfaces import StandardExternalFields
 
 logger = __import__('logging').getLogger(__name__)
 
-
+#: .. deprecated:: 1.0
+#: This is legacy functionality, please do not access directly.
+#: The public interface is through :func:`register_legacy_search_module`
 LEGACY_FACTORY_SEARCH_MODULES = set()
 
 try:
@@ -76,12 +78,15 @@ def register_legacy_search_module(module_name):
     :param module_name: Either the name of a module to look for
         at runtime in :data:`sys.modules`, or a module-like object
         having a ``__dict__``.
+
+    .. deprecated:: 1.0
+        Use explicit mime or class factories instead.
     """
     if module_name:
         LEGACY_FACTORY_SEARCH_MODULES.add(module_name)
 
 
-deprecated('register_legacy_search_module',
+deprecated(('register_legacy_search_module', 'LEGACY_FACTORY_SEARCH_MODULES'),
            "Legacy search modules are deprecated. Prefer to register "
            "explicit mime or class factories. See "
            "https://github.com/NextThought/nti.externalization/issues/35",

--- a/src/nti/externalization/tests/test_autopackage.py
+++ b/src/nti/externalization/tests/test_autopackage.py
@@ -58,6 +58,15 @@ class TestAutoPackageIO(unittest.TestCase):
         assert_that(AutoPackage._ap_find_package_name(),
                     is_('nti.externalization'))
 
+    def test_find_factories_sets_name(self):
+        class AP(AutoPackage):
+            @classmethod
+            def _ap_enumerate_module_names(cls):
+                return ()
+
+        reg = AP._ap_find_factories('nti.externalization.tests')
+        assert_that(reg, has_property('__name__', 'nti.externalization.tests'))
+
     def test_find_interfaces(self):
         from nti.externalization import interfaces
         assert_that(AutoPackage._ap_find_package_interface_module(),

--- a/src/nti/externalization/tests/test_internalization.py
+++ b/src/nti/externalization/tests/test_internalization.py
@@ -102,8 +102,9 @@ class TestFunctions(CleanUp,
         assert_that(INT.find_factory_for_class_name(''), is_(none()))
 
     def test_search_for_factory_updates_search_set(self):
-        INT.LEGACY_FACTORY_SEARCH_MODULES.add(__name__)
+        INT.register_legacy_search_module(__name__)
         assert_that(INT.find_factory_for_class_name('testfunctions'), is_(none()))
+
         assert_that(sys.modules[__name__], is_in(INT.LEGACY_FACTORY_SEARCH_MODULES))
         assert_that(__name__, is_not(is_in(INT.LEGACY_FACTORY_SEARCH_MODULES)))
 


### PR DESCRIPTION
- Issue a FutureWarning if they are imported directly or used.
- Implement the mitigation steps outlined in #35 to make their use less terrible for the time being
  - Try to keep things sorted so we have some determinism
  - Add a cache in the form of the global site manager.
  - Detect conflicting duplicates
  - Warn if we get this far back in the search path.

Fixes #35.