### PR TITLE
 Make ext:registerAutoPackageIO defer its legacy registrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,3 +28,10 @@
   ``ext:registerAutoPackageIO``. Note that we expect the behaviour of
   this attribute to change in the near future.
   See https://github.com/NextThought/nti.externalization/issues/33
+- Make ``ext:registerAutoPackageIO`` perform legacy class
+  registrations when the configuration context executes, not when the
+  directive runs. This means that conflicts in legacy class names will be
+  detected at configuration time. It also means that legacy class names can
+  be registered locally with ``z3c.baseregistry`` (previously they
+  were always registered in the global site manager).
+  See https://github.com/NextThought/nti.externalization/issues/28

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,3 +18,13 @@
 - Deprecate
   ``nti.externalization.internalization.register_legacy_search_module``.
   See https://github.com/NextThought/nti.externalization/issues/35
+- Stop ``ext:registerAutoPackageIO`` from registering the legacy
+  class-name based factories by default. If you need class-name based
+  factories, there are two options. The first is to explicitly
+  register ``IClassObjectFactory`` objects in ZCML (we could add a
+  scanning directive to make that more convenient for large numbers of
+  classes), and the second is to set ``register_legacy_search_module``
+  to a true value in the ZCML directive for
+  ``ext:registerAutoPackageIO``. Note that we expect the behaviour of
+  this attribute to change in the near future.
+  See https://github.com/NextThought/nti.externalization/issues/33

--- a/src/nti/externalization/autopackage.py
+++ b/src/nti/externalization/autopackage.py
@@ -166,7 +166,7 @@ class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO)
             return
 
         ext_class_name = cls._ap_compute_external_class_name_from_concrete_class(implementation_class)
-
+        # XXX: Checking for duplicates
         setattr(namespace,
                 ext_class_name,
                 implementation_class)
@@ -245,11 +245,15 @@ class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO)
         (See :class:`~.InterfaceObjectIO`.)
 
         Then, find all of the object factories and initialize them
-        using :func:`_ap_find_factories`. Finally, the namespace object that was
-        returned is registered using :func:`~.register_legacy_search_module`.
+        using :func:`_ap_find_factories`. A namespace object representing these
+        factories is returned.
 
-        .. note:: In the future, registering this namespace object will be optional
-           and disabled by default.
+        .. versionchanged:: 1.0
+            Registering the factories using :func:`~.register_legacy_search_module`
+            is no longer done by default. If you are using this class outside of ZCML,
+            you will need to subclass and override this method to make that call
+            yourself. If you are using ZCML, you will need to set the appropriate
+            attribute to True.
         """
         # Do nothing when this class itself is initted
         if cls.__name__ == 'AutoPackageSearchingScopedInterfaceObjectIO' \
@@ -271,8 +275,4 @@ class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO)
 
         # Now find the factories
         factories = cls._ap_find_factories(package_name)
-        # XXX: Return this instead of setting it now so that the ZCML
-        # directive has more control.
-        register_legacy_search_module(factories)
-
         return factories

--- a/src/nti/externalization/tests/test_internalization.py
+++ b/src/nti/externalization/tests/test_internalization.py
@@ -616,3 +616,15 @@ class TestValidateFieldValue(CleanUp,
 
         setter = INT.validate_named_field_value(self.Bag(), IFace, 'thing', 42)
         setter()
+
+class TestDeprecation(unittest.TestCase):
+
+    def test_module(self):
+        import types
+        from zope.deprecation.deprecation import DeprecationProxy
+
+        # It's both a module and a deprecated proxy. This
+        # check lets us know that _find_factories_in_module
+        # will do the right thing with deprecated modules.
+        assert_that(INT, is_(DeprecationProxy))
+        assert_that(INT, is_(types.ModuleType))

--- a/src/nti/externalization/tests/test_zcml.py
+++ b/src/nti/externalization/tests/test_zcml.py
@@ -19,7 +19,9 @@ from nti.externalization.interfaces import IMimeObjectFactory
 from nti.testing.matchers import is_empty
 
 from hamcrest import assert_that
-from hamcrest import contains
+from hamcrest import same_instance
+from hamcrest import equal_to
+from hamcrest import is_
 from hamcrest import is_not
 from hamcrest import has_length
 from hamcrest import has_property
@@ -29,7 +31,20 @@ from hamcrest import none
 # pylint: disable=W0212,R0904
 # pylint: disable=inherit-non-class
 
+class RegistrationMixin(object):
+
+    def _getModule(self):
+        import sys
+        return sys.modules[__name__]
+
+    def _addFactory(self, factory, name='Factory'):
+        module = self._getModule()
+        setattr(module, name, factory)
+        self.addCleanup(delattr, module, name)
+
+
 class TestRegisterMimeFactoriesZCML(PlacelessSetup,
+                                    RegistrationMixin,
                                     unittest.TestCase):
 
     SCAN_THIS_MODULE = """
@@ -38,10 +53,6 @@ class TestRegisterMimeFactoriesZCML(PlacelessSetup,
            <ext:registerMimeFactories module="%s" />
         </configure>
         """ % (__name__)
-
-    def _getModule(self):
-        import sys
-        return sys.modules[__name__]
 
     def test_scan_module_with_no_factories(self):
         xmlconfig.string(self.SCAN_THIS_MODULE)
@@ -52,15 +63,12 @@ class TestRegisterMimeFactoriesZCML(PlacelessSetup,
         class O(object):
             __external_can_create__ = True
             mimeType = 'application/foo'
+        self._addFactory(O)
 
-        self._getModule().Factory = O
-        try:
-            xmlconfig.string(self.SCAN_THIS_MODULE)
-            assert_that(component.getUtility(IMimeObjectFactory,
-                                             name=O.mimeType),
-                        is_not(none()))
-        finally:
-            del self._getModule().Factory
+        xmlconfig.string(self.SCAN_THIS_MODULE)
+        assert_that(component.getUtility(IMimeObjectFactory,
+                                         name=O.mimeType),
+                    is_not(none()))
 
     def test_scan_module_with_factories(self):
         class O(object):
@@ -71,22 +79,18 @@ class TestRegisterMimeFactoriesZCML(PlacelessSetup,
             __external_can_create__ = True
             mimeType = 'application/foo2'
 
-        self._getModule().Factory = O
-        self._getModule().Factory2 = P
-        try:
-            xmlconfig.string(self.SCAN_THIS_MODULE)
-            o = component.getUtility(IMimeObjectFactory,
-                                     name=O.mimeType)
-            p = component.getUtility(IMimeObjectFactory,
-                                     name=P.mimeType)
-            assert_that(o,
-                        is_not(none()))
-            assert_that(p,
-                        is_not(none()))
-            assert_that(o, is_not(p))
-        finally:
-            del self._getModule().Factory
-            del self._getModule().Factory2
+        self._addFactory(O)
+        self._addFactory(P, 'Factory2')
+        xmlconfig.string(self.SCAN_THIS_MODULE)
+        o = component.getUtility(IMimeObjectFactory,
+                                 name=O.mimeType)
+        p = component.getUtility(IMimeObjectFactory,
+                                 name=P.mimeType)
+        assert_that(o,
+                    is_not(none()))
+        assert_that(p,
+                    is_not(none()))
+        assert_that(o, is_not(p))
 
     def test_scan_module_with_factories_conflict(self):
         from zope.configuration.config import ConfigurationConflictError
@@ -98,41 +102,31 @@ class TestRegisterMimeFactoriesZCML(PlacelessSetup,
             __external_can_create__ = True
             mimeType = O.mimeType
 
-        self._getModule().Factory = O
-        self._getModule().Factory2 = P
-        try:
-            with self.assertRaises(ConfigurationConflictError):
-                xmlconfig.string(self.SCAN_THIS_MODULE)
-        finally:
-            del self._getModule().Factory
-            del self._getModule().Factory2
+        self._addFactory(O)
+        self._addFactory(P, 'Factory2')
 
+        with self.assertRaises(ConfigurationConflictError):
+            xmlconfig.string(self.SCAN_THIS_MODULE)
 
     def test_scan_module_with_factory_legacy(self):
         class O(object):
             __external_can_create__ = True
             mime_type = 'application/foo'
 
-        self._getModule().Factory = O
-        try:
-            xmlconfig.string(self.SCAN_THIS_MODULE)
-            assert_that(component.getUtility(IMimeObjectFactory,
-                                             name=O.mime_type),
-                        is_not(none()))
-        finally:
-            del self._getModule().Factory
+        self._addFactory(O)
+        xmlconfig.string(self.SCAN_THIS_MODULE)
+        assert_that(component.getUtility(IMimeObjectFactory,
+                                         name=O.mime_type),
+                    is_not(none()))
 
     def test_scan_module_with_factory_no_mime(self):
         class O(object):
             __external_can_create__ = True
 
-        self._getModule().Factory = O
-        try:
-            xmlconfig.string(self.SCAN_THIS_MODULE)
-            gsm = component.getGlobalSiteManager()
-            assert_that(list(gsm.registeredUtilities()), is_empty())
-        finally:
-            del self._getModule().Factory
+        self._addFactory(O)
+        xmlconfig.string(self.SCAN_THIS_MODULE)
+        gsm = component.getGlobalSiteManager()
+        assert_that(list(gsm.registeredUtilities()), is_empty())
 
     def test_scan_module_with_factory_imported(self):
         class O(object):
@@ -141,27 +135,20 @@ class TestRegisterMimeFactoriesZCML(PlacelessSetup,
 
         O.__module__ = '__dynamic__'
 
-        self._getModule().Factory = O
-        try:
-            xmlconfig.string(self.SCAN_THIS_MODULE)
-            gsm = component.getGlobalSiteManager()
-            assert_that(list(gsm.registeredUtilities()), is_empty())
-        finally:
-            del self._getModule().Factory
-
+        self._addFactory(O)
+        xmlconfig.string(self.SCAN_THIS_MODULE)
+        gsm = component.getGlobalSiteManager()
+        assert_that(list(gsm.registeredUtilities()), is_empty())
 
     def test_scan_module_with_factory_non_create(self):
         class O(object):
             __external_can_create__ = False
             mimeType = 'application/foo'
 
-        self._getModule().Factory = O
-        try:
-            xmlconfig.string(self.SCAN_THIS_MODULE)
-            gsm = component.getGlobalSiteManager()
-            assert_that(list(gsm.registeredUtilities()), is_empty())
-        finally:
-            del self._getModule().Factory
+        self._addFactory(O)
+        xmlconfig.string(self.SCAN_THIS_MODULE)
+        gsm = component.getGlobalSiteManager()
+        assert_that(list(gsm.registeredUtilities()), is_empty())
 
 class IExtRoot(interface.Interface):
     pass
@@ -174,6 +161,7 @@ class IOBase(object):
         return sys.modules[__name__]
 
 class TestAutoPackageZCML(PlacelessSetup,
+                          RegistrationMixin,
                           unittest.TestCase):
     SCAN_THIS_MODULE = """
         <configure xmlns:ext="http://nextthought.com/ntp/ext">
@@ -194,7 +182,33 @@ class TestAutoPackageZCML(PlacelessSetup,
         # The root interface was registered
         assert_that(list(gsm.registeredAdapters()), has_length(1))
 
-        # The module was added to the legacy search list
+        # The module was added to the legacy search list directly,
+        # now, producing the factories it needed (which was none)
         with Suppressor():
             assert_that(INT.LEGACY_FACTORY_SEARCH_MODULES,
-                        contains(has_property('__name__', 'nti.externalization.tests')))
+                        is_empty())
+
+
+    def test_scan_package_legacy_utility(self):
+        from nti.externalization import internalization as INT
+        @interface.implementer(IExtRoot)
+        class O(object):
+            __external_can_create__ = True
+            mimeType = 'application/foo'
+
+        self._addFactory(O)
+        xmlconfig.string(self.SCAN_THIS_MODULE)
+        gsm = component.getGlobalSiteManager()
+        # The interfaces IExtRoot and IInternalObjectIO were registered,
+        # as well as an IMimeObjectFactory and that interface,
+        # two variants on ILegacySearchModuleFactory and its interface.
+        assert_that(list(gsm.registeredUtilities()), has_length(7))
+
+        factory = gsm.getUtility(IMimeObjectFactory, 'application/foo')
+        assert_that(factory, has_property('_callable', equal_to(O)))
+
+        factory = gsm.getUtility(INT._ILegacySearchModuleFactory, 'o')
+        assert_that(factory, is_(same_instance(O)))
+
+        factory = gsm.getUtility(INT._ILegacySearchModuleFactory, 'O')
+        assert_that(factory, is_(same_instance(O)))


### PR DESCRIPTION
This lets it detect conflicts. This also lets it be used with `<registerIn>` to localize them (yay).

I did *not* add an escape hatch to make it register them eagerly still and ignore conflicts, but we can if that turns out to be necessary.

Fixes #28

Currently based on #38