### PR TITLE
Drop hard dependency on Acquisition and speed up removeAllProxies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,3 +38,5 @@
 - Drop dependency on ``zope.preference``. It was not used by this
   package, although our ``configure.zcml`` did include it. If you use
   ``zope.preference``, please include it in your own ZCML file.
+- Drop hard dependency on Acquisition. It is still used if available
+  and is used in test mode.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     tests_require=TESTS_REQUIRE,
     install_requires=[
         'setuptools',
-        'Acquisition',
         'BTrees',
         'isodate',
         'nti.schema',

--- a/src/nti/externalization/proxy.py
+++ b/src/nti/externalization/proxy.py
@@ -3,43 +3,74 @@
 """
 Utilities for working with various kinds of transparent proxies.
 
-.. $Id$
 """
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import Acquisition
-import zope.container.contained
-import zope.proxy
+from zope.dottedname import resolve as dottedname
 
 _unwrappers = []
-_unwrappers.append(zope.proxy.removeAllProxies)
-_unwrappers.append(zope.container.contained.getProxiedObject)
-#aq_base = getattr(Acquisition, 'aq_base')
-_unwrappers.append(Acquisition.aq_base)
+
+def _init_unwrappers():
+    del _unwrappers[:]
+    for funcname in (
+            'zope.proxy.removeAllProxies',
+            'zope.container.contained.getProxiedObject',
+            'Acquisition.aq_base',
+    ):
+        try:
+            func = dottedname.resolve(funcname)
+        except ImportError: # pragma: no cover
+            pass
+        else:
+            registerProxyUnwrapper(func)
 
 def removeAllProxies(proxy):
     """
-    If the object in ``proxy`` is proxied by one of the types
+    If the object in *proxy* is proxied by one of the types
     of proxies known about by this module, remove all of the
     known proxies, unwrapping down to the original base object.
 
-    This module may know about :mod:`zope.proxy`, :mod:`zope.container.contained`,
-    and :mod:`Acquisition`.
+    This module may know about :mod:`zope.proxy`,
+    :mod:`zope.container.contained`, and :mod:`Acquisition`,
+    if they are installed.
+
+    .. versionchanged:: 1.0
+       The default proxy unwrappers are all optional and will only
+       be registered if they can be imported.
     """
 
-    fully_unwrapped_by = [False] * len(_unwrappers)
-
-    while not all(fully_unwrapped_by):
-        for i, unwrapper in enumerate(_unwrappers):
+    go_again = True
+    while go_again:
+        for unwrapper in _unwrappers:
             unwrapped = unwrapper(proxy)
             if unwrapped is not proxy:
-                # It changed something. reset the whole state.
-                fully_unwrapped_by[:] = [False] * len(_unwrappers)
                 proxy = unwrapped
-            else:
-                # yes, this one is completely done
-                fully_unwrapped_by[i] = True
-    return proxy
+                break
+        else:
+            # We didn't break. Nothing unwrapped.
+            go_again = False
+    return unwrapped
+
+def registerProxyUnwrapper(func):
+    """
+    Register a function that can unwrap a single proxy from
+    a proxied object. If there is nothing to unwrap, the function
+    should return the given object.
+
+    .. versionadded:: 1.0
+       This is a provisional way to extend the unwrapping functionality
+       (where speed is critical). It may not be supported in the future.
+    """
+    _unwrappers.append(func)
+
+try:
+    from zope.testing import cleanup
+except ImportError: # pragma: no cover
+    pass
+else:
+    cleanup.addCleanUp(_init_unwrappers)
+
+_init_unwrappers()


### PR DESCRIPTION
Acquisition is still used if available, and is still a test dependency, but it is not a hard installation dependency anymore.

The function proxy.removeAllProxies is called typically at least twice for every object we externalize (when getting oids), making its speed important. The function was naievly written and quite slow.

For a deeply wrapped object (10 layers of proxies in arbitrary orders), the new implementation is roughly 2.9x faster (16.9s vs 6.0s). For (the common case of) an object with no wrapper, it's about 2.2x faster (2.23s vs 1.05s). (All numbers in CPython 2.7.)