### PR TITLE
Begin work on a simple benchmarking framework using perf

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 source = nti.externalization
 omit =
     */flycheck_*py
+    */benchmarks/*py
 
 [report]
 exclude_lines =

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,3 +52,7 @@
   See https://github.com/NextThought/nti.externalization/issues/43
 - Add the ``<ext:classObjectFactory>`` directive for registering
   ``Class`` based factories. (Note: MIME factories are preferred.)
+- Callers of ``to_standard_external_dictionary`` (which includes
+  AutoPackageScopedInterfaceIO) will now automatically get a
+  ``MimeType`` value if one can be found. Previously only callers of
+  ``to_minimal_standard_external_dictionary`` would.

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,9 @@ setup(
             'repoze.sphinx.autointerface',
             'sphinx_rtd_theme',
         ],
+        'benchmarks': [
+            'perf',
+        ],
 
     },
     entry_points=entry_points,

--- a/src/nti/externalization/externalization.py
+++ b/src/nti/externalization/externalization.py
@@ -525,13 +525,7 @@ def to_standard_external_dictionary(self, mergeFrom=None,
         be added to the dictionary created by this method. The keys and
         values in ``mergeFrom`` should already be external.
     """
-    result = LocatedExternalDict()
-
-    if mergeFrom:
-        result.update(mergeFrom)
-
-    if request is _NotGiven:
-        request = get_current_request()
+    result = to_minimal_standard_external_dictionary(self, mergeFrom)
 
     set_external_identifiers(self, result)
 
@@ -543,14 +537,15 @@ def to_standard_external_dictionary(self, mergeFrom=None,
     to_standard_external_last_modified_time(self, _write_into=result)
     to_standard_external_created_time(self, _write_into=result)
 
-    _ext_class_if_needed(self, result)
-
     containerId = _choose_field(result, self, StandardExternalFields_CONTAINER_ID,
                                 fields=(StandardInternalFields_CONTAINER_ID,))
     if containerId:  # alias per mobile client request 20150625
         result[StandardInternalFields_CONTAINER_ID] = containerId
 
     if decorate:
+        if request is _NotGiven:
+            request = get_current_request()
+
         decorate_external_mapping(self, result, registry=registry,
                                   request=request)
     elif callable(decorate_callback):
@@ -587,7 +582,7 @@ def to_minimal_standard_external_dictionary(self, mergeFrom=None, **unused_kwarg
         result.update(mergeFrom)
     _ext_class_if_needed(self, result)
 
-    mime_type = getattr(self, 'mime_type', None)
+    mime_type = getattr(self, 'mimeType', None) or getattr(self, 'mime_type', None)
     if mime_type:
         result[StandardExternalFields_MIMETYPE] = mime_type
     return result

--- a/src/nti/externalization/tests/benchmarks/__init__.py
+++ b/src/nti/externalization/tests/benchmarks/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+A package for benchmarking code.
+
+benchmarks should be performed using the `perf module
+<https://perf.readthedocs.io/en/latest/>`_.
+
+The overall design is taken from `performance
+<https://github.com/python/performance/tree/master/performance>`_.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function

--- a/src/nti/externalization/tests/benchmarks/__main__.py
+++ b/src/nti/externalization/tests/benchmarks/__main__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Main file to run when the package is specified. Primary CLI.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import glob
+import os
+import os.path
+
+import perf
+from zope.dottedname import resolve as dottedname
+
+here = os.path.dirname(__file__)
+
+def find_benchmarks():
+    modules = []
+    fnames = [os.path.basename(f)[:-3]
+              for f
+              in glob.glob(os.path.join(here, 'bm_*.py'))]
+
+    modules = [dottedname.resolve('nti.externalization.tests.benchmarks.' + f)
+               for f in fnames]
+    return modules
+
+def main():
+
+    runner = perf.Runner()
+    for mod in find_benchmarks():
+        mod.main(runner)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/nti/externalization/tests/benchmarks/bm_simple_iface.py
+++ b/src/nti/externalization/tests/benchmarks/bm_simple_iface.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+Benchmark for a simple registered autopackage IFace with
+a single text field.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import perf
+from zope.configuration import xmlconfig
+
+from nti.externalization.externalization import toExternalObject
+from nti.externalization.interfaces import StandardExternalFields
+from nti.externalization.internalization import default_externalized_object_factory_finder
+from nti.externalization.internalization import update_from_external_object
+import nti.externalization.tests.benchmarks
+from nti.externalization.tests.benchmarks.objects import DerivedWithOneTextField
+
+
+def main(runner=None):
+
+    xmlconfig.file('configure.zcml', nti.externalization.tests.benchmarks)
+
+    obj = DerivedWithOneTextField()
+    obj.text = u"This is some text"
+
+    assert obj.mimeType == 'application/vnd.nextthought.benchmarks.derivedwithonetextfield'
+
+    def func():
+        toExternalObject(obj)
+
+    runner = runner or perf.Runner()
+    runner.bench_func(__name__ + ": toExternalObject", func)
+
+    ext = toExternalObject(obj)
+    assert StandardExternalFields.MIMETYPE in ext
+
+    def from_():
+        obj = default_externalized_object_factory_finder(ext)()
+        update_from_external_object(obj, ext)
+
+    runner.bench_func(__name__ + ": fromExternalObject", from_)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/src/nti/externalization/tests/benchmarks/bm_simple_registered_class.py
+++ b/src/nti/externalization/tests/benchmarks/bm_simple_registered_class.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+Benchmark for a simple registered Class factory object.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import perf
+from zope.configuration import xmlconfig
+
+from nti.externalization.externalization import toExternalObject
+from nti.externalization.interfaces import StandardExternalFields
+from nti.externalization.internalization import default_externalized_object_factory_finder
+from nti.externalization.internalization import update_from_external_object
+import nti.externalization.tests.benchmarks
+from nti.externalization.tests.benchmarks.objects import SimplestPossibleObject
+
+
+def main(runner=None):
+
+    xmlconfig.file('configure.zcml', nti.externalization.tests.benchmarks)
+
+    obj = SimplestPossibleObject()
+
+    def func():
+        toExternalObject(obj)
+
+    runner = runner or perf.Runner()
+    runner.bench_func(__name__ + ": toExternalObject", func)
+
+    ext = toExternalObject(obj)
+    ext.pop(StandardExternalFields.MIMETYPE, None)
+
+    def from_():
+        obj = default_externalized_object_factory_finder(ext)()
+        update_from_external_object(obj, ext)
+
+    runner.bench_func(__name__ + ": fromExternalObject", from_)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/src/nti/externalization/tests/benchmarks/configure.zcml
+++ b/src/nti/externalization/tests/benchmarks/configure.zcml
@@ -1,0 +1,16 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+		   xmlns:ext="http://nextthought.com/ntp/ext">
+
+	<include package="zope.component" />
+
+	<include package="nti.externalization" file="meta.zcml" />
+	<include package="nti.externalization" />
+
+	<ext:classObjectFactory factory=".objects.SimplestPossibleObject" />
+
+	<ext:registerAutoPackageIO
+		root_interfaces=".interfaces.IRootInterface"
+		modules=".objects"
+		/>
+
+</configure>

--- a/src/nti/externalization/tests/benchmarks/interfaces.py
+++ b/src/nti/externalization/tests/benchmarks/interfaces.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Interfaces for objects we will benchmark with.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope.interface import Interface
+from zope.interface import taggedValue
+
+from nti.schema.field import TextLine
+
+class ISimplestPossibleObject(Interface):
+    """
+    This will be a very simple object, with no
+    schema and no fields to set.
+    """
+
+class IRootInterface(Interface):
+    """
+    A root interface.
+    """
+
+class IDerivedWithOneTextField(IRootInterface):
+
+    text = TextLine(title=u"Some text", required=True)
+
+    taggedValue('__external_class_name__',
+                'DerivedWithOneTextField')

--- a/src/nti/externalization/tests/benchmarks/objects.py
+++ b/src/nti/externalization/tests/benchmarks/objects.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Implementations of interfaces.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope import interface
+
+from nti.externalization.datastructures import ExternalizableInstanceDict
+from nti.schema.fieldproperty import createDirectFieldProperties
+
+from . import interfaces
+
+
+@interface.implementer(interfaces.ISimplestPossibleObject)
+class SimplestPossibleObject(ExternalizableInstanceDict):
+    __external_can_create__ = True
+    mimeType = 'application/vnd.nextthought.benchmarks.simplestpossibleobject'
+
+
+@interface.implementer(interfaces.IDerivedWithOneTextField)
+class DerivedWithOneTextField(object):
+    createDirectFieldProperties(interfaces.IDerivedWithOneTextField)

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -516,6 +516,9 @@ class TestToExternalObject(ExternalizationLayerTest):
         result = to_minimal_standard_external_dictionary(O(), mergeFrom={'abc': 42})
         assert_that(result, is_({'abc': 42, 'Class': 'O', 'MimeType': 'application/thing'}))
 
+        result = to_standard_external_dictionary(O(), mergeFrom={'abc': 42})
+        assert_that(result, is_({'abc': 42, 'Class': 'O', 'MimeType': 'application/thing'}))
+
     def test_name_falls_back_to_standard_name(self):
         toExternalObject(self, name='a name')
 


### PR DESCRIPTION
**Also** ensure that more externalized objects get a MimeType by default. (This was necessary to be able to benchmark the different registry approaches.)

Refs #36 

Current benchmark output:

* CPython 2.7
```
.....................
bm_simple_iface: toExternalObject: Mean +- std dev: 82.7 us +- 2.1 us
.....................
bm_simple_iface: fromExternalObject: Mean +- std dev: 145 us +- 5 us
.....................
bm_simple_registered_class: toExternalObject: Mean +- std dev: 69.6 us +- 3.3 us
.....................
bm_simple_registered_class: fromExternalObject: Mean +- std dev: 30.5 us +- 1.2 us
```

* CPython 3.6
```
.....................
bm_simple_iface: toExternalObject: Mean +- std dev: 61.3 us +- 2.9 us
.....................
bm_simple_iface: fromExternalObject: Mean +- std dev: 139 us +- 6 us
.....................
bm_simple_registered_class: toExternalObject: Mean +- std dev: 48.7 us +- 1.9 us
.....................
bm_simple_registered_class: fromExternalObject: Mean +- std dev: 47.5 us +- 1.6 us
```

* PyPy 5.8.0
```
.........
bm_simple_iface: toExternalObject: Mean +- std dev: 7.67 us +- 0.69 us
.........
bm_simple_iface: fromExternalObject: Mean +- std dev: 18.8 us +- 0.9 us
.........
bm_simple_registered_class: toExternalObject: Mean +- std dev: 5.94 us +- 0.28 us
........
bm_simple_registered_class: fromExternalObject: Mean +- std dev: 1.22 us +- 0.07 us
```
