### PR TITLE
SingletonMetaclass no longer creates actual singletons.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
   ``update_from_external_object``. See
   https://github.com/NextThought/nti.externalization/issues/29.
 
+- THe ``SingletonMetaclass`` no longer actually enforces the singleton
+  property. It turns out to be faster to run the usual constructors.
+  See https://github.com/NextThought/nti.externalization/issues/48
+
 
 1.0.0a1 (2017-09-29)
 ====================

--- a/src/nti/externalization/tests/benchmarks/bm_singleton.py
+++ b/src/nti/externalization/tests/benchmarks/bm_singleton.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Benchmark for creating singleton objects.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import perf
+
+from nti.externalization.singleton import Singleton
+from nti.externalization.singleton import SingletonMetaclass
+
+# These are defined to have __slots__ = ()
+class SingletonSubclass(Singleton):
+    pass
+
+
+class ObjectSubclass(object):
+    __slots__ = ()
+    def __init__(self, _context=None, _request=None):
+        pass
+
+
+def main(runner=None):
+
+    runner = runner or perf.Runner()
+    runner.bench_func('Construct Singleton', SingletonSubclass)
+
+    runner.bench_func('Construct non-Singleton', ObjectSubclass)
+
+    runner.bench_func('Construct Singleton with args',
+                      SingletonSubclass, 'context', 'request')
+
+    runner.bench_func("Construct non-Singleton with args",
+                      ObjectSubclass, 'context', 'request')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/nti/externalization/tests/test_dublincore.py
+++ b/src/nti/externalization/tests/test_dublincore.py
@@ -10,11 +10,12 @@ from __future__ import print_function
 # stdlib imports
 import unittest
 
+from nti.externalization.singleton import Singleton
 from . import ExternalizationLayerTest
 
 from hamcrest import assert_that
 from hamcrest import is_
-from hamcrest import same_instance
+
 
 # disable: accessing protected members, too many methods
 # pylint: disable=W0212,R0904
@@ -34,7 +35,9 @@ class AbstractDCDecoratorTest(object):
         x = self._makeOne()
         y = self._makeOne()
 
-        assert_that(x, is_(same_instance(y)))
+        assert_that(x, is_(y))
+        assert_that(hash(x), is_(hash(y)))
+        assert_that(x, is_(Singleton))
 
 
 class TestDCextendedExternalMappingDecorator(AbstractDCDecoratorTest,


### PR DESCRIPTION
This is faster by about a third.

CPython 2.7 before:
```
.....................
Construct Singleton: Mean +- std dev: 293 ns +- 10 ns
.....................
Construct non-Singleton: Mean +- std dev: 195 ns +- 4 ns
.....................
Construct Singleton with args: Mean +- std dev: 309 ns +- 8 ns
.....................
Construct non-Singleton with args: Mean +- std dev: 211 ns +- 4 ns
```
After:
```
.....................
Construct Singleton: Mean +- std dev: 200 ns +- 5 ns
.....................
Construct non-Singleton: Mean +- std dev: 198 ns +- 6 ns
.....................
Construct Singleton with args: Mean +- std dev: 213 ns +- 6 ns
.....................
Construct non-Singleton with args: Mean +- std dev: 212 ns +- 4 ns
```
CPython 3.6 before:
```
.....................
Construct Singleton: Mean +- std dev: 345 ns +- 7 ns
.....................
Construct non-Singleton: Mean +- std dev: 252 ns +- 4 ns
.....................
Construct Singleton with args: Mean +- std dev: 390 ns +- 14 ns
.....................
Construct non-Singleton with args: Mean +- std dev: 292 ns +- 7 ns
.....................
```
After:
```
.....................
Construct Singleton: Mean +- std dev: 257 ns +- 8 ns
.....................
Construct non-Singleton: Mean +- std dev: 259 ns +- 7 ns
.....................
Construct Singleton with args: Mean +- std dev: 295 ns +- 8 ns
.....................
Construct non-Singleton with args: Mean +- std dev: 295 ns +- 9 ns
```
Fixes #48.