### PR TITLE
Use the shared interface cache to speed up modified notifications

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,16 @@ if not PYPY:
             ('internalization.legacy_factories', ()),
             ('internalization.factories', ()),
             ('internalization.fields', ()),
-            ('internalization.events', ()),
+            ('internalization.events', ('_interface_cache',)),
             ('internalization.externals', ()),
             ('internalization.updater', ()),
             ('externalization', ('_base_interfaces',)),
-            ('datastructures', ('_base_interfaces', 'externalization',
-                                'internalization')),
+            ('_interface_cache', ()),
+            ('datastructures', (
+                '_base_interfaces',
+                '_interface_cache',
+                'externalization',
+                'internalization')),
     ):
         deps = ([_py_source(mod) for mod in deps]
                 + [_pxd(mod) for mod in deps]

--- a/src/nti/externalization/__interface_cache.pxd
+++ b/src/nti/externalization/__interface_cache.pxd
@@ -1,0 +1,20 @@
+import cython
+
+cdef cache_instances
+
+@cython.final
+@cython.internal
+@cython.freelist(1000)
+cdef class InterfaceCache(object):
+    cdef __weakref__
+    cdef iface
+    cdef frozenset ext_all_possible_keys
+    cdef ext_accept_external_id
+    cdef frozenset ext_primitive_out_ivars
+    cdef dict modified_event_attributes
+
+@cython.locals(x=InterfaceCache)
+cdef _cache_cleanUp(instances)
+
+cpdef InterfaceCache cache_for(externalizer, ext_self)
+cpdef InterfaceCache cache_for_key(key, ext_self)

--- a/src/nti/externalization/_datastructures.pxd
+++ b/src/nti/externalization/_datastructures.pxd
@@ -15,6 +15,8 @@ from nti.externalization.__base_interfaces cimport StandardInternalFields as SIF
 
 from nti.externalization.internalization._fields cimport validate_named_field_value
 
+from nti.externalization.__interface_cache cimport cache_for
+
 cdef IInternalObjectIO
 cdef SEF StandardExternalFields
 cdef SIF StandardInternalFields
@@ -72,19 +74,5 @@ cdef class ModuleScopedInterfaceObjectIO(InterfaceObjectIO):
     )
     cpdef _ext_schemas_to_consider(self, ext_self)
 
-@cython.final
-@cython.internal
-@cython.freelist(1000)
-cdef class _InterfaceCache(object):
-    cdef __weakref__
-    cdef iface
-    cdef frozenset ext_all_possible_keys
-    cdef ext_accept_external_id
-    cdef frozenset ext_primitive_out_ivars
-
-
-cdef _InterfaceCache _cache_for(externalizer, ext_self)
-@cython.locals(x=_InterfaceCache)
-cdef _cache_cleanUp()
 
 cdef tuple _primitives

--- a/src/nti/externalization/_interface_cache.py
+++ b/src/nti/externalization/_interface_cache.py
@@ -1,0 +1,84 @@
+# cython: auto_pickle=False,embedsignature=True,always_allow_keywords=False
+# -*- coding: utf-8 -*-
+"""
+A cache based on the interfaces provided by an object.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from weakref import WeakSet
+
+from zope.interface import providedBy
+
+cache_instances = WeakSet()
+
+
+class InterfaceCache(object):
+    # Although having a __dict__ would be more convenient,
+    # since this object is used from multiple modules,
+    # Cython code is much more effective if the fields are
+    # defined in the .pxd --- which translate to slots
+    # in Python
+
+    __slots__ = (
+        'iface',
+        'ext_all_possible_keys',
+        'ext_accept_external_id',
+        'ext_primitive_out_ivars',
+        'modified_event_attributes',
+        '__weakref__'
+    )
+
+    def __init__(self):
+        self.iface = None
+        self.ext_all_possible_keys = None
+        self.ext_accept_external_id = None
+        self.ext_primitive_out_ivars = None
+        self.modified_event_attributes = {}
+
+
+
+def cache_for_key(key, ext_self):
+    # The Declaration objects maintain a _v_attrs that
+    # gets blown away on changes to themselves or their
+    # dependents, including adding interfaces dynamically to an instance
+    # (In that case, the provided object actually gets reset)
+    cache_place = providedBy(ext_self)
+    try:
+        attrs = cache_place._v_attrs # pylint:disable=protected-access
+    except AttributeError:
+        attrs = cache_place._v_attrs = {}
+
+    try:
+        cache = attrs[key]
+    except KeyError:
+        cache = InterfaceCache()
+        attrs[key] = cache
+        cache_instances.add(cache)
+
+    return cache
+
+
+def cache_for(externalizer, ext_self):
+    return cache_for_key(type(externalizer), ext_self)
+
+
+def _cache_cleanUp(instances):
+    for x in list(instances):
+        x.__init__()
+
+
+try:
+    from zope.testing import cleanup
+except ImportError: # pragma: no cover
+    pass
+else:
+    cleanup.addCleanUp(_cache_cleanUp, args=(cache_instances,))
+
+
+# pylint:disable=wrong-import-position
+from nti.externalization._compat import import_c_accel
+import_c_accel(globals(), 'nti.externalization.__interface_cache')

--- a/src/nti/externalization/internalization/_events.pxd
+++ b/src/nti/externalization/internalization/_events.pxd
@@ -1,7 +1,7 @@
 # definitions for internalization.py
 import cython
 
-
+from nti.externalization.__interface_cache cimport cache_for_key
 
 # imports
 cdef providedBy
@@ -15,8 +15,10 @@ cdef class _Attributes(object):
     cdef public interface
     cdef public set attributes
 
+
 @cython.locals(
-    attrs=_Attributes,
+    attrs=dict,
+    attributes=_Attributes,
 )
 cdef _make_modified_attributes(containedObject, external_keys)
 


### PR DESCRIPTION
This shows a 5-7% improvement on the interface-based
fromExternalObject benchmark.