### PR TITLE
Remove special handling of creator from choose_field. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@
   ``decorate`` is false. This argument is also confusing and should be
   considered deprecated.
 
+- ``choose_field`` no longer has the undocumented conversion behaviour for the
+  CREATOR external field name.
+
 1.0.0a1 (2017-09-29)
 ====================
 

--- a/src/nti/externalization/externalization/__init__.py
+++ b/src/nti/externalization/externalization/__init__.py
@@ -33,8 +33,8 @@ from nti.externalization.extension_points import get_current_request
 from .replacers import NonExternalizableObjectError
 
 from .fields import choose_field
-from .fields import SYSTEM_USER_NAME
 
+from .standard_fields import SYSTEM_USER_NAME
 from .standard_fields import get_last_modified_time
 from .standard_fields import get_created_time
 

--- a/src/nti/externalization/externalization/_fields.pxd
+++ b/src/nti/externalization/externalization/_fields.pxd
@@ -7,20 +7,11 @@ from nti.externalization.__base_interfaces cimport StandardExternalFields as SEF
 
 cdef SEF StandardExternalFields
 
-
 # Imports
-cdef type text_type
 
 
 # Constants
-cdef basestring _SYSTEM_USER_NAME
-cdef basestring _SYSTEM_USER_ID
-cdef identity
-cdef IPrincipal_providedBy
 cdef logger
-
-
-cdef bint is_system_user(obj) except *
 
 cpdef choose_field(result, self,
                    unicode ext_name,

--- a/src/nti/externalization/externalization/_standard_fields.pxd
+++ b/src/nti/externalization/externalization/_standard_fields.pxd
@@ -9,6 +9,7 @@ from nti.externalization.externalization._fields cimport choose_field
 
 # Imports
 cdef IDCTimes
+cdef type text_type
 
 
 # Constants
@@ -23,12 +24,20 @@ cdef tuple _CREATOR_FIELDS
 cdef tuple _CONTAINER_FIELDS
 cdef _EXT_CLASS_IGNORED_MODULES
 
+cdef basestring _SYSTEM_USER_NAME
+cdef basestring _SYSTEM_USER_ID
+cdef IPrincipal_providedBy
+
+
 cpdef datetime_to_unix_time(dt)
 
 cpdef get_last_modified_time(context, default=*, _write_into=*)
 cpdef get_created_time(context, default=*, _write_into=*)
 
+cdef _system_user_converter(obj)
 cpdef get_creator(context, default=*, _write_into=*)
+
+
 cpdef get_container_id(context, default=*, _write_into=*)
 
 cpdef get_class(context, _write_into=*)

--- a/src/nti/externalization/externalization/fields.py
+++ b/src/nti/externalization/externalization/fields.py
@@ -8,10 +8,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from six import text_type
 
-from zope.security.management import system_user
-from zope.security.interfaces import IPrincipal
 
 
 from nti.externalization._base_interfaces import get_standard_external_fields
@@ -19,20 +16,6 @@ from nti.externalization._base_interfaces import get_standard_external_fields
 logger = __import__('logging').getLogger(__name__)
 
 StandardExternalFields = get_standard_external_fields()
-identity = lambda obj: obj
-
-
-_SYSTEM_USER_NAME = getattr(system_user, 'title').lower()
-SYSTEM_USER_NAME = _SYSTEM_USER_NAME # Export from cython to python
-_SYSTEM_USER_ID = system_user.id
-del system_user
-
-IPrincipal_providedBy = IPrincipal.providedBy
-del IPrincipal
-
-def is_system_user(obj):
-    return IPrincipal_providedBy(obj) and obj.id == _SYSTEM_USER_ID
-
 
 def choose_field(result, self, ext_name,
                  converter=None,
@@ -46,22 +29,12 @@ def choose_field(result, self, ext_name,
         if value is None:
             continue
 
-        # If the creator is the system user, catch it here
-        # XXX: Document this behaviour.
-        if ext_name == StandardExternalFields.CREATOR:
-            if is_system_user(value):
-                value = SYSTEM_USER_NAME
-            else:
-                # This is a likely recursion point, we want to be
-                # sure we don't do that.
-                value = text_type(value)
-            result[ext_name] = value
-            return value
         if converter is not None:
             value = converter(value)
         if value is not None:
             result[ext_name] = value
             return value
+
 
     # Nothing. Can we adapt it?
     if sup_iface is not None and sup_fields:


### PR DESCRIPTION
Instead it is done by get_creator.

get_creator no longer calls choose_field, it doesn't use any of the special features that were possible (like adaptation). This lets cython directly call system_user_converter.

Fixes #59.