### PR TITLE
Optimize and cache the signature computation for update.updateFromExternalObject

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,20 @@
 - Proxies around objects that implement ``toExternalObject`` are
   allowed again; the proxied object's ``toExternalObject`` will be called.
 
+- The signature for ``updateFromExternalObject()`` has been tightened.
+  It should be ``(self, external_object, context, **kwargs)``, where
+  ``**kwargs`` is optional, as is context. ``**kwargs`` currently
+  contains nothing useful. Uses of ``dataserver=None`` in the
+  signature will generate a warning. This may be tightened further in
+  the future. See `issue 30
+  <https://github.com/NextThought/nti.externalization/issues/30>`_.
+
+- ``__ext_ignore_updateFromExternalObject__`` is officially
+  deprecated and generates a warning.
+
+- ``update_from_external_object`` caches certain information about the
+  types of the updater objects, making it 8-25% faster.
+
 
 1.0.0a2 (2018-07-05)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@
 1.0.0a3 (unreleased)
 ====================
 
-- Nothing changed yet.
+- Proxies around objects that implement ``toExternalObject`` are
+  allowed again; the proxied object's ``toExternalObject`` will be called.
 
 
 1.0.0a2 (2018-07-05)

--- a/src/nti/externalization/datastructures.py
+++ b/src/nti/externalization/datastructures.py
@@ -432,8 +432,8 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
                 cache.ext_accept_external_id = False
         return cache.ext_accept_external_id
 
-    def updateFromExternalObject(self, parsed, *args, **kwargs):
-        result = super(InterfaceObjectIO, self).updateFromExternalObject(parsed, *args, **kwargs)
+    def updateFromExternalObject(self, parsed, *unused_args, **unused_kwargs):
+        result = AbstractDynamicObjectIO.updateFromExternalObject(self, parsed)
         # If we make it this far, then validate the object.
 
         # TODO: Should probably just make sure that there are no /new/

--- a/src/nti/externalization/externalization/__init__.py
+++ b/src/nti/externalization/externalization/__init__.py
@@ -107,8 +107,9 @@ def toExternalDictionary(*args, **kwargs): # pragma: no cover
     return to_standard_external_dictionary(*args, **kwargs)
 
 
-def is_nonstr_iter(v):
-    warnings.warn("'is_nonstr_iter' will be deleted.", FutureWarning)
+def is_nonstr_iter(v): # pragma: no cover
+    warnings.warn("'is_nonstr_iter' will be deleted. It is broken on Python 3",
+                  FutureWarning, stacklevel=2)
     return hasattr(v, '__iter__')
 
 
@@ -116,9 +117,10 @@ def removed_unserializable(ext):
     # pylint:disable=too-many-branches
     # XXX: Why is this here? We don't use it anymore.
     # Can it be removed?
-    warnings.warn("'removed_unserializable' will be deleted.", FutureWarning)
+    warnings.warn("'removed_unserializable' will be deleted.", FutureWarning, stacklevel=2)
     def _is_sequence(m):
-        return not isinstance(m, collections.Mapping) and is_nonstr_iter(m)
+        return (not isinstance(m, (str, collections.Mapping))
+                and hasattr(m, '__iter__'))
 
     def _clean(m):
         if isinstance(m, collections.Mapping):

--- a/src/nti/externalization/externalization/_externalizer.pxd
+++ b/src/nti/externalization/externalization/_externalizer.pxd
@@ -91,7 +91,7 @@ cdef _usable_externalObject_cache_get
 @cython.locals(
     has_ext_obj=bint,
 )
-cdef _obj_has_usable_externalObject(obj)
+cpdef _obj_has_usable_externalObject(obj)
 
 cdef _externalize_object(obj, _ExternalizationState state)
 

--- a/src/nti/externalization/externalization/externalizer.py
+++ b/src/nti/externalization/externalization/externalizer.py
@@ -184,9 +184,11 @@ else:
 
 
 def _obj_has_usable_externalObject(obj):
-    # This is for legacy code support, to allow existing methods to move to adapters
-    # and call us without infinite recursion
-    kind = type(obj)
+    # This is for legacy code support, to allow existing methods to
+    # move to adapters and call us without infinite recursion.
+    # We use __class__ instead of type() to allow for proxies;
+    # The proxy itself cannot implement toExternalObject
+    kind = obj.__class__
     answer = _usable_externalObject_cache_get(kind)
     if answer is None:
         answer = False

--- a/src/nti/externalization/externalization/externalizer.py
+++ b/src/nti/externalization/externalization/externalizer.py
@@ -252,7 +252,7 @@ def _to_external_object_state(obj, state, top_level=False):
         elif result is not _marker:
             return result
         else:
-            logger.warn("Recursive call to object %s.", obj)
+            logger.warning("Recursive call to object %s.", obj)
             result = internal_to_standard_external_dictionary(obj,
                                                               decorate=False)
 

--- a/src/nti/externalization/externalization/tests/test_externalizer.py
+++ b/src/nti/externalization/externalization/tests/test_externalizer.py
@@ -40,7 +40,7 @@ class TestFunctions(unittest.TestCase):
         class Proxy(ProxyBase):
 
             def toExternalObject(self, **kwargs):
-                return {'a': 42}
+                raise NotImplementedError
 
         self.assertFalse(_obj_has_usable_externalObject(Proxy(object())))
 

--- a/src/nti/externalization/externalization/tests/test_externalizer.py
+++ b/src/nti/externalization/externalization/tests/test_externalizer.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
+
+import unittest
+
+from zope.proxy import ProxyBase
+
+from nti.externalization.externalization import to_external_object
+from ..externalizer import _obj_has_usable_externalObject
+
+
+class WithToExternalObject(object):
+
+    def toExternalObject(self, **kwargs):
+        return {'a': 42}
+
+
+
+class TestFunctions(unittest.TestCase):
+
+    def test_non_proxied(self):
+        self.assertTrue(_obj_has_usable_externalObject(WithToExternalObject()))
+
+    def test_has_usable_external_object_proxied(self):
+
+        obj = WithToExternalObject()
+        proxied = ProxyBase(obj)
+
+        self.assertTrue(_obj_has_usable_externalObject(proxied))
+        self.assertEqual({'a': 42}, to_external_object(proxied))
+
+    def test_proxy_has_usable_external_object_not_allowed(self):
+
+        class Proxy(ProxyBase):
+
+            def toExternalObject(self, **kwargs):
+                return {'a': 42}
+
+        self.assertFalse(_obj_has_usable_externalObject(Proxy(object())))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/nti/externalization/interfaces.py
+++ b/src/nti/externalization/interfaces.py
@@ -288,15 +288,19 @@ class IInternalObjectUpdater(interface.Interface):
 		It should return the new value. Note that the function here is at most
 		a class or static method, not an instance method.""")
 
-    def updateFromExternalObject(externalObject, *args, **kwargs):
+    def updateFromExternalObject(externalObject, context, **kwargs):
         """
         Update the object this is adapting from the external object.
-        Two alternate signatures are supported, one with ``dataserver`` instead of
-        context, and one with no keyword args.
+
+        Alternately, the signature can be ``updateFromExternalObject(externalObject)``
+        or simply ``updateFromExternalObject(externalObject, **kwargs)``. In this
+        last case, ``context`` will be passed as a value in ``**kwargs``.
+
 
         :return: If not ``None``, a value that can be interpreted as a boolean,
                 indicating whether or not the internal object actually
-                underwent updates. If ``None``, no meaning is assigned (to allow older
+                underwent updates. If ``None``, the caller should assume that the object
+                was updated (to allow older
                 code that doesn't return at all.)
         """
 

--- a/src/nti/externalization/internalization/_updater.pxd
+++ b/src/nti/externalization/internalization/_updater.pxd
@@ -31,9 +31,9 @@ cdef dict _EMPTY_DICT
 cdef class _RecallArgs(object):
     cdef registry
     cdef context
-    cdef require_updater
-    cdef notify
     cdef pre_hook
+    cdef bint require_updater
+    cdef bint notify
 
 
 cdef _recall(k, obj, ext_obj, _RecallArgs kwargs)
@@ -42,6 +42,15 @@ cpdef update_from_external_object(containedObject,
                                   externalObject,
                                   registry=*,
                                   context=*,
-                                  require_updater=*,
-                                  notify=*,
+                                  bint require_updater=*,
+                                  bint notify=*,
                                   pre_hook=*)
+
+cdef dict _argspec_cacheg
+cdef str _UPDATE_ARGS_TWO
+cdef str _UPDATE_ARGS_ONE
+cdef str _UPDATE_ARGS_CONTEXT_KW
+cdef _get_update_signature(updater)
+
+cdef dict _upsable_updateFromExternalObject_cache
+cdef _obj_has_usable_updateFromExternalObject(obj)

--- a/src/nti/externalization/internalization/updater.py
+++ b/src/nti/externalization/internalization/updater.py
@@ -41,16 +41,16 @@ class _RecallArgs(object):
         'pre_hook',
     )
 
-    def __init__(self, registry,
-                 context,
-                 require_updater,
-                 notify,
-                 pre_hook):
-        self.registry = registry
-        self.context = context
-        self.require_updater = require_updater
-        self.notify = notify
-        self.pre_hook = pre_hook
+    # We don't have an __init__, we ask the caller
+    # to fill us in. In cython, this avoids some
+    # unneeded bint->object->bint conversions.
+
+    def __init__(self):
+        self.registry = None
+        self.context = None
+        self.require_updater = False
+        self.notify = True
+        self.pre_hook = None
 
 
 def _recall(k, obj, ext_obj, kwargs):
@@ -63,8 +63,104 @@ def _recall(k, obj, ext_obj, kwargs):
                                       notify=kwargs.notify,
                                       pre_hook=kwargs.pre_hook)
     if IPersistent_providedBy(obj): # pragma: no cover
-        obj._v_updated_from_external_source = ext_obj
+        obj._v_updated_from_external_source = ext_obj # pylint:disable=protected-access
     return obj
+
+##
+# Note on caching: We do not expect the updater objects to be proxied.
+# So we directly use type() instead of .__class__, which is faster.
+# We also do not expect them to be unloaded/updated/unbounded,
+# so we use a regular dict to cache info about them, which is faster
+# than a WeakKeyDictionary. For the same reason, we use dynamic warning
+# strings.
+
+# Support for varying signatures of the updater. This is slow and
+# cumbersome and needs to go; we are in the deprecation period now.
+# See https://github.com/NextThought/nti.externalization/issues/30
+
+_argspec_cache = {}
+
+# update(ext, context) or update(ext, context=None) or update(ext, dataserver)
+# exactly two arguments. It doesn't matter what the name is, we'll call it
+# positional.
+_UPDATE_ARGS_TWO = "update args two"
+_UPDATE_ARGS_CONTEXT_KW = "update args **kwargs"
+_UPDATE_ARGS_ONE = "update args external only"
+
+
+def _get_update_signature(updater):
+    kind = type(updater)
+
+    spec = _argspec_cache.get(kind)
+    if spec is None:
+        try:
+            argspec = inspect.getargspec(updater.updateFromExternalObject)
+        except TypeError: # pragma: no cover (This is hard to catch in pure-python coverage mode)
+            # Cython functions and other extension types are "not a Python function"
+            # and don't work with this. We assume they use the standard form accepting
+            # 'context' as kwarg
+            spec = _UPDATE_ARGS_CONTEXT_KW
+        else:
+            # argspec.args contains the names of all the parameters.
+            # argspec.keywords, if not none, is the name of the **kwarg
+            # These all must be methods (or at least classmethods), having
+            # an extra 'self' argument.
+            if not argspec.keywords:
+                # No **kwarg, good!
+                if len(argspec.args) == 3:
+                    # update(ext, context) or update(ext, context=None) or update(ext, dataserver)
+                    spec = _UPDATE_ARGS_TWO
+                else:
+                    # update(ext)
+                    spec = _UPDATE_ARGS_ONE
+            else:
+                if len(argspec.args) == 3:
+                    # update(ext, context, **kwargs) or update(ext, dataserver, **kwargs)
+                    spec = _UPDATE_ARGS_TWO
+                elif argspec.keywords.startswith("unused") or argspec.keywords.startswith('_'):
+                    spec = _UPDATE_ARGS_ONE
+                else:
+                    spec = _UPDATE_ARGS_CONTEXT_KW
+
+            if 'dataserver' in argspec.args and argspec.defaults and len(argspec.defaults) >= 1:
+                warnings.warn("The type %r still uses updateFromExternalObject(dataserver=None). "
+                              "Please change to context=None." % (kind,),
+                              FutureWarning)
+
+        _argspec_cache[kind] = spec
+
+    return spec
+
+_usable_updateFromExternalObject_cache = {}
+
+def _obj_has_usable_updateFromExternalObject(obj):
+    kind = type(obj)
+
+    usable_from = _usable_updateFromExternalObject_cache.get(kind)
+    if usable_from is None:
+        has_update = hasattr(obj, 'updateFromExternalObject')
+        if not has_update:
+            usable_from = False
+        else:
+            wants_ignore = getattr(obj, '__ext_ignore_updateFromExternalObject__', False)
+            usable_from = not wants_ignore
+            if wants_ignore:
+                warnings.warn("The type %r has __ext_ignore_updateFromExternalObject__=True. "
+                              "Please remove updateFromExternalObject from the type." % (kind,),
+                              FutureWarning)
+
+
+        _usable_updateFromExternalObject_cache[kind] = usable_from
+
+    return usable_from
+
+try:
+    from zope.testing import cleanup # pylint:disable=ungrouped-imports
+except ImportError: # pragma: no cover
+    raise
+else:
+    cleanup.addCleanUp(_argspec_cache.clear)
+    cleanup.addCleanUp(_usable_updateFromExternalObject_cache.clear)
 
 
 def update_from_external_object(containedObject, externalObject,
@@ -102,7 +198,7 @@ def update_from_external_object(containedObject, externalObject,
         Signature ``f(k,x)`` where ``k`` is either the key name, or
         None in the case of a sequence and ``x`` is the external
         object. Deprecated.
-    :return: `containedObject` after updates from `externalObject`
+    :return: *containedObject* after updates from *externalObject*
 
     .. versionchanged:: 1.0.0a2
        Remove the ``object_hook`` parameter.
@@ -112,13 +208,12 @@ def update_from_external_object(containedObject, externalObject,
         for i in range(3):
             warnings.warn('pre_hook is deprecated', FutureWarning, stacklevel=i)
 
-    kwargs = _RecallArgs(
-        registry,
-        context,
-        require_updater,
-        notify,
-        pre_hook
-    )
+    kwargs = _RecallArgs()
+    kwargs.registry = registry
+    kwargs.context = context
+    kwargs.require_updater = require_updater
+    kwargs.notify = notify
+    kwargs.pre_hook = pre_hook
 
 
     # Parse any contained objects
@@ -168,8 +263,7 @@ def update_from_external_object(containedObject, externalObject,
                 externalObject[k] = _recall(k, factory(), v, kwargs)
 
     updater = None
-    if hasattr(containedObject, 'updateFromExternalObject') \
-        and not getattr(containedObject, '__ext_ignore_updateFromExternalObject__', False):
+    if _obj_has_usable_updateFromExternalObject(containedObject):
         # legacy support. The __ext_ignore_updateFromExternalObject__
         # allows a transition to an adapter without changing
         # existing callers and without triggering infinite recursion
@@ -189,24 +283,14 @@ def update_from_external_object(containedObject, externalObject,
 
         updated = None
         # The signature may vary.
-        # XXX: This is slow and cumbersome and needs to go.
-        # See https://github.com/NextThought/nti.externalization/issues/30
-        try:
-            argspec = inspect.getargspec(updater.updateFromExternalObject)
-        except TypeError: # pragma: no cover (This is hard to catch in pure-python coverage mode)
-            # Cython functions and other extension types are "not a Python function"
-            # and don't work with this. We assume they use the standard form accepting
-            # 'context' as kwarg
-            updated = updater.updateFromExternalObject(externalObject, context=context)
+        arg_kind = _get_update_signature(updater)
+        if arg_kind is _UPDATE_ARGS_TWO:
+            updated = updater.updateFromExternalObject(externalObject, context)
+        elif arg_kind is _UPDATE_ARGS_ONE:
+            updated = updater.updateFromExternalObject(externalObject)
         else:
-            if 'context' in argspec.args or (argspec.keywords and 'dataserver' not in argspec.args):
-                updated = updater.updateFromExternalObject(externalObject,
-                                                           context=context)
-            elif argspec.keywords or 'dataserver' in argspec.args:
-                updated = updater.updateFromExternalObject(externalObject,
-                                                           dataserver=context)
-            else:
-                updated = updater.updateFromExternalObject(externalObject)
+            updated = updater.updateFromExternalObject(externalObject,
+                                                       context=context)
 
         # Broadcast a modified event if the object seems to have changed.
         if notify and (updated is None or updated):
@@ -214,6 +298,7 @@ def update_from_external_object(containedObject, externalObject,
                             updater, external_keys, _EMPTY_DICT)
 
     return containedObject
+
 
 
 from nti.externalization._compat import import_c_accel # pylint:disable=wrong-import-position,wrong-import-order

--- a/src/nti/externalization/tests/benchmarks/bm_simple_registered_class.py
+++ b/src/nti/externalization/tests/benchmarks/bm_simple_registered_class.py
@@ -17,6 +17,22 @@ from nti.externalization.internalization import update_from_external_object
 import nti.externalization.tests.benchmarks
 from nti.externalization.tests.benchmarks.objects import SimplestPossibleObject
 
+# pylint:disable=arguments-differ
+
+class NoArgs(SimplestPossibleObject):
+
+    def updateFromExternalObject(self, external_object):
+        self.__dict__.update(external_object)
+
+class ContextArg(SimplestPossibleObject):
+
+    def updateFromExternalObject(self, external_object, context=None):
+        self.__dict__.update(external_object)
+
+class DSArg(SimplestPossibleObject):
+
+    def updateFromExternalObject(self, external_object, dataserver=None):
+        self.__dict__.update(external_object)
 
 def main(runner=None):
 
@@ -38,6 +54,27 @@ def main(runner=None):
         update_from_external_object(obj, ext)
 
     runner.bench_func(__name__ + ": fromExternalObject", from_)
+
+
+    def no_args():
+        obj = NoArgs()
+        update_from_external_object(obj, ext)
+
+    def context_arg():
+        obj = ContextArg()
+        update_from_external_object(obj, ext)
+
+    def ds_arg():
+        obj = DSArg()
+        update_from_external_object(obj, ext)
+
+
+    runner.bench_func(__name__ + ": fromExternalObject (no args)", no_args)
+
+    runner.bench_func(__name__ + ": fromExternalObject (context arg)", context_arg)
+
+    runner.bench_func(__name__ + ": fromExternalObject (ds arg)", ds_arg)
+
 
 
 

--- a/src/nti/externalization/tests/benchmarks/bm_simple_registered_class.py
+++ b/src/nti/externalization/tests/benchmarks/bm_simple_registered_class.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 import perf
 from zope.configuration import xmlconfig
 
@@ -73,6 +75,7 @@ def main(runner=None):
 
     runner.bench_func(__name__ + ": fromExternalObject (context arg)", context_arg)
 
+    warnings.simplefilter('ignore')
     runner.bench_func(__name__ + ": fromExternalObject (ds arg)", ds_arg)
 
 

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -204,22 +204,23 @@ class TestFunctions(ExternalizationLayerTest):
 
 
     def test_removed_unserializable(self):
+        import warnings
         marker = object()
         ext = {'x': 1, 'y': [1, 2, marker], 'z': marker,
                'a': {3, 4}, 'b': {'c': (marker, 1)}}
-        removed_unserializable(ext)
+        with warnings.catch_warnings(record=True): # removed_unserializable is deprecated
+            assert_that(removed_unserializable((1, 2, 3)),
+                        is_([1, 2, 3]))
+
+            assert_that(removed_unserializable([[(1, 2, 3)]]),
+                        is_([[[1, 2, 3]]]))
+            removed_unserializable(ext)
         assert_that(ext, has_entry('x', is_(1)))
         assert_that(ext, has_entry('y', is_([1, 2, None])))
         assert_that(ext, has_entry('a', is_([3, 4])))
         assert_that(ext, has_entry('z', is_(none())))
         assert_that(ext, has_entry('b', has_entry('c', is_([None, 1]))))
 
-
-        assert_that(removed_unserializable((1, 2, 3)),
-                    is_([1, 2, 3]))
-
-        assert_that(removed_unserializable([[(1, 2, 3)]]),
-                    is_([[[1, 2, 3]]]))
 
     def test_devmode_non_externalizable_object_replacer(self):
         assert_that(calling(DevmodeNonExternalizableObjectReplacementFactory(None)).with_args(self),

--- a/src/nti/externalization/tests/test_internalization.py
+++ b/src/nti/externalization/tests/test_internalization.py
@@ -106,7 +106,7 @@ class TestFunctions(CleanUp,
     def test_search_for_factory_updates_search_set(self):
         from zope.testing.loggingsupport import InstalledHandler
 
-        with warnings.catch_warnings():
+        with warnings.catch_warnings(record=True):
             INT.register_legacy_search_module(__name__)
             # The cache is initialized lazily
             assert_that(__name__, is_in(INT.LEGACY_FACTORY_SEARCH_MODULES))
@@ -483,6 +483,7 @@ class TestUpdateFromExternaObject(CleanUp,
         with warnings.catch_warnings(record=True) as w:
             self._callFUT(contained, {})
         assert_that(contained, has_property('updated', True))
+        __traceback_info__ = [repr(i.__dict__) for i in w]
         assert_that(w, has_length(1))
 
     def test_update_mapping_with_registered_factory(self):

--- a/src/nti/externalization/tests/test_zcml.py
+++ b/src/nti/externalization/tests/test_zcml.py
@@ -190,7 +190,6 @@ class TestAutoPackageZCML(PlacelessSetup,
 
 
     def test_scan_package_legacy_utility(self):
-        from nti.externalization import internalization as INT
         @interface.implementer(IExtRoot)
         class O(object):
             __external_can_create__ = True
@@ -229,13 +228,17 @@ class TestClassObjectFactory(PlacelessSetup,
         </configure>
     """ % (__name__,)
 
+    assertRaisesRegex = getattr(unittest.TestCase,
+                                'assertRaisesRegex',
+                                unittest.TestCase.assertRaisesRegexp)
+
     def test_scan_no_create(self):
         class O(object):
             pass
 
         self._addFactory(O)
-        with self.assertRaisesRegexp(xmlconfig.ZopeXMLConfigurationError,
-                                     "must set __external_can_create__ to true"):
+        with self.assertRaisesRegex(xmlconfig.ZopeXMLConfigurationError,
+                                    "must set __external_can_create__ to true"):
             xmlconfig.string(self.SCAN_THIS_MODULE.replace('PLACEHOLDER', ''))
 
     def test_scan_not_callable(self):
@@ -244,8 +247,8 @@ class TestClassObjectFactory(PlacelessSetup,
 
         self._addFactory(O())
 
-        with self.assertRaisesRegexp(xmlconfig.ZopeXMLConfigurationError,
-                                     "must be callable"):
+        with self.assertRaisesRegex(xmlconfig.ZopeXMLConfigurationError,
+                                    "must be callable"):
             xmlconfig.string(self.SCAN_THIS_MODULE.replace('PLACEHOLDER', ''))
 
     def test_scan_no_name(self):


### PR DESCRIPTION
This lets us be 8-27% faster.

Also officially deprecate with a warning some of the older signatures. This addresses (but doesn't quite fix) #30 

| Benchmark | 27_src_all_no_cache | 27_src_all_caches_3          |
|---------------------------------------------------------------------------------------------------|---------------------|------------------------------|
| .bm_simple_iface: find factory                                | 4.01 us             | 3.96 us: 1.01x faster (-1%)  |
| .bm_simple_iface: fromExternalObject                          | 70.4 us             | 65.0 us: 1.08x faster (-8%)  |
| .bm_simple_registered_class: fromExternalObject               | 13.6 us             | 10.9 us: 1.25x faster (-20%) |
| .bm_simple_registered_class: fromExternalObject (no args)     | 21.2 us             | 16.2 us: 1.31x faster (-24%) |
| .bm_simple_registered_class: fromExternalObject (context arg) | 21.3 us             | 16.2 us: 1.32x faster (-24%) |
| .bm_simple_registered_class: fromExternalObject (ds arg)      | 22.1 us             | 16.1 us: 1.37x faster (-27%) |

Not significant (6): Construct Singleton; Construct non-Singleton; Construct Singleton with args; Construct non-Singleton with args; nti.externalization.tests.benchmarks.bm_simple_iface: toExternalObject; nti.externalization.tests.benchmarks.bm_simple_registered_class: toExternalObject