### PR TITLE
InterfaceObjectIO uses its newfound powers to make Dict fields internalize easier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,12 @@
   `PR 68
   <https://github.com/NextThought/nti.externalization/pull/68>`_.
 
+- Schemas that use ``InterfaceObjectIO`` (including through the ZCML
+  directive ``registerAutoPackageIO``) can use ``Dict`` fields more
+  easily on internalization (externalization has always worked): They
+  automatically internalize their values by treating the ``Dict`` as
+  anonymous external data.
+
 1.0.0a2 (2018-07-05)
 ====================
 

--- a/src/nti/externalization/_datastructures.pxd
+++ b/src/nti/externalization/_datastructures.pxd
@@ -28,6 +28,8 @@ cdef make_repr
 cdef isSyntheticKey
 cdef find_most_derived_interface
 cdef NotGiven
+cdef IDict_providedBy
+cdef _anonymous_dict_factory
 
 cdef class ExternalizableDictionaryMixin(object):
     # This is a mixin used with other C base classes (E.g., persistent)

--- a/src/nti/externalization/tests/benchmarks/configure.zcml
+++ b/src/nti/externalization/tests/benchmarks/configure.zcml
@@ -13,9 +13,4 @@
 		modules=".objects"
 		/>
 
-    <ext:anonymousObjectFactoryInPlace
-        for=".interfaces.IUserContactProfile"
-        field="addresses"
-        />
-
 </configure>


### PR DESCRIPTION
Previously (as of this morning) you needed a ZCML entry; before that it was extra manual work.