### PR TITLE
Look for IInternalObjectIO adapters as well as INamedExternalizedObje…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,13 @@
 1.0.0a5 (unreleased)
 ====================
 
-- Nothing changed yet.
+- Objects inheriting from ``InterfaceObjectIO`` and registered with
+  the component registry (in ZCML) for ``IInternalObjectIO`` can still
+  be found and used as ``INamedExternalizedObjectFactoryFinder``, an
+  interface implemented by ``InterfaceObjectIO`` through
+  ``IInternalObjectIOFinder``. A warning will be issued to update the
+  registration (which generally means removing the ``provides`` line
+  in ZCML).
 
 
 1.0.0a4 (2018-07-30)

--- a/src/nti/externalization/internalization/_updater.pxd
+++ b/src/nti/externalization/internalization/_updater.pxd
@@ -16,6 +16,7 @@ cdef iteritems
 cdef component
 cdef interface
 cdef IInternalObjectUpdater
+cdef IInternalObjectIO
 cdef INamedExternalizedObjectFactoryFinder
 
 # optimizations
@@ -53,6 +54,7 @@ cdef _invoke_updater(containedObject, externalObject, updater,
 cdef _update_sequence(externalObject, _RecallArgs args,
                       destination_name=*,
                       find_factory_for_named_value=*)
+cpdef _find_INamedExternalizedObjectFactoryFinder(containedObject, registry)
 cdef _update_from_external_object(containedObject, externalObject, _RecallArgs args)
 
 cpdef update_from_external_object(containedObject,


### PR DESCRIPTION
…ctFactoryFinder

Objects inheriting from ``InterfaceObjectIO`` and registered with the
component registry (in ZCML) for ``IInternalObjectIO`` can still be
found and used as ``INamedExternalizedObjectFactoryFinder``, an
interface implemented by ``InterfaceObjectIO`` through
``IInternalObjectIOFinder``. A warning will be issued to update the
registration (which generally means removing the ``provides`` line in
ZCML).

This should help in legacy cases.

See https://github.com/NextThought/nti.xapi/pull/25#discussion_r206176747