### PR TITLE
Make ExternalizableInstanceDict subclassable along with Persistent.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 
 - Nothing changed yet.
 
+- ``ExternalizableInstanceDict`` no longer inherits from
+  ``AbstractDynamicIO``, it just implements the same interface (with
+  the exception of many of the ``_ext`` methods). This class is deprecated.
 
 1.0.0a4 (2018-07-30)
 ====================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,12 +192,14 @@ intersphinx_mapping = {
     'http://zopecontainer.readthedocs.io/en/latest': None,
     'http://zopedatetime.readthedocs.io/en/latest': None,
     'http://zopedublincore.readthedocs.io/en/latest': None,
+    'http://zopeevent.readthedocs.io/en/latest': None,
     'http://zopehookable.readthedocs.io/en/latest': None,
     'http://zopeinterface.readthedocs.io/en/latest': None,
     'http://zopeintid.readthedocs.io/en/latest/': None,
     'http://zopemimetype.readthedocs.io/en/latest/': None,
     'http://zopeproxy.readthedocs.io/en/latest': None,
     'http://zopeschema.readthedocs.io/en/latest/': None,
+    'http://zopelifecycleevent.readthedocs.io/en/latest/': None,
 }
 
 extlinks = {

--- a/src/nti/externalization/_datastructures.pxd
+++ b/src/nti/externalization/_datastructures.pxd
@@ -56,9 +56,15 @@ cdef class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
     cpdef find_factory_for_named_value(self, key, value, registry)
     cdef _updateFromExternalObject(self, parsed)
 
+# cdef class _ExternalizableInstanceDict(AbstractDynamicObjectIO):
+#     cdef dict __dict__
 
-cdef class ExternalizableInstanceDict(AbstractDynamicObjectIO):
-    pass
+
+# This class is sometimes subclassed while also subclassing persistent.Persistent,
+# which doesn't work if it's an extension class, so we can't do that. It's rarely used,
+# so performance doesn't matter as much.
+#cdef class ExternalizableInstanceDict(AbstractDynamicObjectIO):
+#    pass
 
 cdef class InterfaceObjectIO(AbstractDynamicObjectIO):
     cdef readonly _ext_self

--- a/src/nti/externalization/interfaces.py
+++ b/src/nti/externalization/interfaces.py
@@ -398,12 +398,15 @@ class IObjectModifiedFromExternalEvent(IObjectModifiedEvent):
     """
     An object has been updated from an external value.
     """
-    kwargs = interface.Attribute("The key word arguments")
+    kwargs = interface.Attribute("The keyword arguments")
     external_value = interface.Attribute("The external value")
 
 
 @interface.implementer(IObjectModifiedFromExternalEvent)
 class ObjectModifiedFromExternalEvent(ObjectModifiedEvent):
+    """
+    Default implementation of `IObjectModifiedFromExternalEvent`.
+    """
 
     kwargs = None
     external_value = None

--- a/src/nti/externalization/internalization/__init__.py
+++ b/src/nti/externalization/internalization/__init__.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 from zope.interface.interfaces import ComponentLookupError
 
 __all__ = [
@@ -20,7 +22,7 @@ __all__ = [
     'default_externalized_object_factory_finder_factory',
     'find_factory_for_class_name',
     'find_factory_for',
-    'notifyModified',
+    'notify_modified',
     'validate_field_value',
     'validate_named_field_value',
 ]
@@ -37,7 +39,7 @@ from .factories import default_externalized_object_factory_finder_factory
 from .factories import find_factory_for_class_name
 from .factories import find_factory_for
 
-from .events import notifyModified
+from .events import notifyModified as notify_modified
 
 from .updater import update_from_external_object
 
@@ -64,3 +66,13 @@ def new_from_external_object(external_object, *args, **kwargs):
     if factory is None:
         raise ComponentLookupError("No factory for object", external_object)
     return update_from_external_object(factory(), external_object, *args, **kwargs)
+
+
+def notifyModified(*args, **kwargs):
+    """
+    A deprecated alias of `notify_modified`.
+
+    .. deprecated:: 1.0a5
+    """
+    warnings.warn("Use notify_modified instead", FutureWarning, stacklevel=2)
+    return notify_modified(*args, **kwargs)

--- a/src/nti/externalization/internalization/events.py
+++ b/src/nti/externalization/internalization/events.py
@@ -133,6 +133,31 @@ def _notifyModified(containedObject, externalObject, updater, external_keys,
 
 def notifyModified(containedObject, externalObject, updater=None, external_keys=None,
                    **kwargs):
+    """
+    Create and send an `~.ObjectModifiedFromExternalEvent` for
+    *containedObject* using `zope.event.notify`.
+
+    The *containedObject* is the subject of the event. The
+    *externalObject* is the dictionary of data that was used to update
+    the *containedObject*.
+
+    *external_keys* is list of keys from *externalObject* that
+    actually changed *containedObject*. If this is not given, we
+    assume that all keys in *externalObject* were changed. Note that
+    these should to correspond to the interface fields of interfaces
+    that the *containedObject* implements in order to properly be able
+    to create and populate the `zope.lifecycleevent` `~zope.lifecycleevent.IAttributes`.
+
+    *updater*, if given, is the `~nti.externalization.interfaces.IInternalObjectUpdater`
+    instance that was used to handle the updates. If this object implements
+    an ``_ext_adjust_modified_event`` method, it will be called to adjust (and return)
+    the event object that will be notified.
+
+    *kwargs* are the keyword arguments passed to the event constructor.
+
+    :return: The event object that was notified.
+    """
+
     return _notifyModified(containedObject, externalObject, updater, external_keys,
                            kwargs)
 

--- a/src/nti/externalization/tests/test_datastructures.py
+++ b/src/nti/externalization/tests/test_datastructures.py
@@ -514,3 +514,16 @@ class TestExternalizableInstanceDict(CommonTestMixins,
                 return context
 
         return FUT()
+
+
+    def test_can_also_subclass_persistent(self):
+        from nti.externalization.datastructures import ExternalizableInstanceDict
+        from persistent import Persistent
+
+        class Base(ExternalizableInstanceDict):
+            pass
+
+        class P(Base, Persistent):
+            pass
+
+        self.assertIsNotNone(P)


### PR DESCRIPTION
Do this with delegation.

Docs-deprecate this class, it was a bad idea.