### PR TITLE
``StandardExternalFields`` and ``StandardInternalFields`` are depreca…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 - ``InterfaceObjectIO`` only returns an anonymous factory for ``IDict``
   fields when it wants objects for the value.
 
+- ``StandardExternalFields`` and ``StandardInternalFields`` are
+  deprecated aliases in ``nti.externalization.externalization``.
 
 1.0.0a5 (2018-07-30)
 ====================

--- a/src/nti/externalization/externalization/__init__.py
+++ b/src/nti/externalization/externalization/__init__.py
@@ -22,6 +22,7 @@ import collections
 import warnings
 
 from zope import component
+from zope import deferredimport
 
 from nti.externalization._base_interfaces import MINIMAL_SYNTHETIC_EXTERNAL_KEYS
 from nti.externalization._base_interfaces import isSyntheticKey
@@ -149,3 +150,11 @@ def removed_unserializable(ext):
         ext = list(ext)
     _clean(ext)
     return ext
+
+deferredimport.initialize()
+deferredimport.deprecatedFrom(
+    "Import from .interfaces",
+    "nti.externalization.interfaces",
+    "StandardExternalFields",
+    "StandardInternalFields",
+)

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -686,3 +686,26 @@ class TestNoPickle(unittest.TestCase):
 
     def test_decorator(self):
         assert_does_not_pickle(DoNotPickleMe())
+
+
+class TestDeprecatedImports(unittest.TestCase):
+
+    def test_SEF(self):
+        from nti.externalization import externalization
+        from nti.externalization import interfaces
+        import warnings
+
+        with warnings.catch_warnings(record=True):
+            sef = getattr(externalization, 'StandardExternalFields')
+
+        assert_that(sef, is_(same_instance(interfaces.StandardExternalFields)))
+
+    def test_SIF(self):
+        from nti.externalization import externalization
+        from nti.externalization import interfaces
+        import warnings
+
+        with warnings.catch_warnings(record=True):
+            sif = getattr(externalization, 'StandardInternalFields')
+
+        assert_that(sif, is_(same_instance(interfaces.StandardInternalFields)))


### PR DESCRIPTION
…ted aliases in ``nti.externalization.externalization``.