### PR TITLE
Allow subclasses of InterfaceObjectIO to have non-frozenset values for _ext_primitive_out_ivars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@
 1.0.0a9 (unreleased)
 ====================
 
-- Nothing changed yet.
+- Allow subclasses of ``InterfaceObjectIO`` to have non-frozenset
+  values for ``_ext_primitive_out_ivars_``. This issues a warning and
+  in the future will be a TypeError.
 
 
 1.0.0a8 (2018-08-16)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ entry_points = {
     'console_scripts': [
     ],
     'zest.releaser.prereleaser.before': [
+        # XXX This only works if we do `fullrelease`.
         'rm_cflags = nti.externalization._compat:release_remove_cflags',
     ],
 }

--- a/src/nti/externalization/datastructures.py
+++ b/src/nti/externalization/datastructures.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 
 # stdlib imports
 import numbers
-
+import warnings
 
 import six
 from six import iteritems
@@ -500,7 +500,18 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
 
         if not cache.ext_primitive_out_ivars:
             keys = self._ext_find_primitive_keys()
-            cache.ext_primitive_out_ivars = self._ext_primitive_out_ivars_ | keys
+            primitives = self._ext_primitive_out_ivars_
+            if not isinstance(primitives, frozenset):
+                warnings.warn(
+                    "Class %r should have a frozenset for _ext_primitive_out_ivars_."
+                    "Make InterfaceObjectIO._ext_primitive_out_ivars_ the LHS of the | operator."
+                    "This will be a TypeError in the future" % (
+                        type(self)
+                    ),
+                    FutureWarning,
+                )
+                primitives = frozenset(primitives)
+            cache.ext_primitive_out_ivars = primitives | keys
         self._ext_primitive_out_ivars_ = cache.ext_primitive_out_ivars
 
         self.validate_after_update = validate_after_update

--- a/src/nti/externalization/tests/test_datastructures.py
+++ b/src/nti/externalization/tests/test_datastructures.py
@@ -197,6 +197,22 @@ class TestInterfaceObjectIO(CleanUp,
         assert_that(inst, has_property('schema', interface.Interface))
         assert_that(result, is_(set()))
 
+    def test_subclass_with_set_ext_primitive_out_ivars(self):
+        import warnings
+        class Bad(self._getTargetClass()):
+            _ext_primitive_out_ivars_ = {'a', 'b'}
+
+        # Use a unique name based on the target class so that we get
+        # a warning when this test class is subclassed.
+        Bad.__name__ = 'Bad' + self._getTargetClass().__name__
+
+        with warnings.catch_warnings(record=True) as w:
+            Bad(object(), interface.Interface)
+
+        self.assertEqual(len(w), 1)
+        self.assertIn("should have a frozenset",
+                      str(w[0].message))
+
     def test_find_primitive_keys_plain_attribute(self):
 
         class I(interface.Interface):
@@ -485,7 +501,6 @@ class TestInterfaceObjectIO(CleanUp,
 
     def test_no_factory_for_dict_with_non_object_value(self):
         from zope.schema import Dict
-        from zope.schema import Object
         from zope.schema import TextLine
         from zope import component
 


### PR DESCRIPTION
Raise a warning when they do.