### PR TITLE
Deprecate and ignore most registry arguments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,13 @@
 1.0.0a10 (unreleased)
 =====================
 
-- Nothing changed yet.
+- The ``registry`` argument to most functions is deprecated and
+  ignored. Instead of making calls to ``registry.queryAdapter``, we
+  now invoke the interface directly. For example,
+  ``IInternalObjectExternalizer(containedObject)``. This lets
+  individual objects have a say if they already provide the interface
+  without going through the legacy code paths (it also calls
+  ``__conform__`` on the object if needed).
 
 
 1.0.0a9 (2018-08-20)

--- a/src/nti/externalization/_datastructures.pxd
+++ b/src/nti/externalization/_datastructures.pxd
@@ -17,6 +17,7 @@ from nti.externalization.internalization._factories cimport find_factory_for
 
 from nti.externalization.__interface_cache cimport cache_for
 
+cdef getUtility
 cdef IDict
 cdef IObject
 cdef IInternalObjectIOFinder
@@ -54,7 +55,7 @@ cdef class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
     cpdef _ext_accept_update_key(self, k, ext_self, ext_keys)
     cpdef _ext_accept_external_id(self, ext_self, parsed)
 
-    cpdef find_factory_for_named_value(self, key, value, registry)
+    cpdef find_factory_for_named_value(self, key, value)
     cdef _updateFromExternalObject(self, parsed)
 
 cdef class _ExternalizableInstanceDict(AbstractDynamicObjectIO):

--- a/src/nti/externalization/datastructures.py
+++ b/src/nti/externalization/datastructures.py
@@ -21,6 +21,7 @@ import six
 from six import iteritems
 from zope import interface
 from zope import schema
+from zope.component import getUtility
 from zope.schema.interfaces import SchemaNotProvided
 from zope.schema.interfaces import IDict
 from zope.schema.interfaces import IObject
@@ -148,7 +149,7 @@ class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
     _ext_primitive_out_ivars_ = frozenset()
     _prefer_oid_ = False
 
-    def find_factory_for_named_value(self, key, value, registry):
+    def find_factory_for_named_value(self, key, value):
         """
         Uses `.find_factory_for` to locate a factory.
 
@@ -156,7 +157,7 @@ class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
         or the *key*. It only handles finding factories based on the
         class or MIME type found within *value*.
         """
-        return find_factory_for(value, registry)
+        return find_factory_for(value)
 
     def _ext_replacement(self):
         # Redeclare this here for cython
@@ -592,7 +593,7 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
                 cache.ext_accept_external_id = False
         return cache.ext_accept_external_id
 
-    def find_factory_for_named_value(self, key, value, registry):
+    def find_factory_for_named_value(self, key, value):
         """
         If `AbstractDynamicObjectIO.find_factory_for_named_value`
         cannot find a factory based on examining *value*, then we use
@@ -629,7 +630,7 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
            it wants objects for the value.
 
         """
-        factory = AbstractDynamicObjectIO.find_factory_for_named_value(self, key, value, registry)
+        factory = AbstractDynamicObjectIO.find_factory_for_named_value(self, key, value)
         if factory is None:
             # Is there a factory on the field?
             try:
@@ -649,7 +650,7 @@ class InterfaceObjectIO(AbstractDynamicObjectIO):
                 # When it is a string, we require the factory to exist.
                 # Anything else is a programming error.
                 if isinstance(factory, str):
-                    factory = registry.getUtility(IAnonymousObjectFactory, factory)
+                    factory = getUtility(IAnonymousObjectFactory, factory)
 
                 if (
                         factory is None

--- a/src/nti/externalization/externalization/_decorate.pxd
+++ b/src/nti/externalization/externalization/_decorate.pxd
@@ -1,6 +1,7 @@
 cdef get_current_request
 cdef NotGiven
 cdef IExternalMappingDecorator
+cdef subscribers
 
 cpdef decorate_external_object(bint do_decorate, call_if_not_decorate,
                                decorate_interface, str decorate_meth_name,

--- a/src/nti/externalization/externalization/_dictionary.pxd
+++ b/src/nti/externalization/externalization/_dictionary.pxd
@@ -33,7 +33,6 @@ cdef NotGiven
 
 cpdef LED internal_to_standard_external_dictionary(self,
                                                    mergeFrom=*,
-                                                   registry=*,
                                                    bint decorate=*,
                                                    request=*,
                                                    decorate_callback=*)

--- a/src/nti/externalization/externalization/_externalizer.pxd
+++ b/src/nti/externalization/externalization/_externalizer.pxd
@@ -10,7 +10,9 @@ cdef defaultdict
 cdef six
 cdef numbers
 
-cdef component
+
+cdef queryAdapter
+cdef getAdapter
 cdef IFiniteSequence
 
 cdef ThreadLocalManager
@@ -24,6 +26,7 @@ cdef INonExternalizableReplacement
 cdef INonExternalizableReplacer
 cdef DefaultNonExternalizableReplacer
 cdef NotGiven
+cdef IInternalObjectExternalizer
 
 
 # Constants
@@ -44,7 +47,6 @@ cdef class _ExternalizationState(object):
     cdef dict memo
 
     cdef basestring name
-    cdef registry
     cdef catch_components
     cdef catch_component_action
     cdef request

--- a/src/nti/externalization/externalization/decorate.py
+++ b/src/nti/externalization/externalization/decorate.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 # Our request hook function always returns None, and pylint
 # flags that as useless (good for it)
 # pylint:disable=assignment-from-none
-
+from zope.component import subscribers
 
 from nti.externalization.extension_points import get_current_request
 from nti.externalization._base_interfaces import NotGiven
@@ -21,9 +21,10 @@ from nti.externalization.interfaces import IExternalMappingDecorator
 def decorate_external_object(do_decorate, call_if_not_decorate,
                              decorate_interface, decorate_meth_name,
                              original_object, external_object,
-                             registry, request):
+                             registry, # ignored
+                             request):
     if do_decorate:
-        for decorator in registry.subscribers((original_object,), decorate_interface):
+        for decorator in subscribers((original_object,), decorate_interface):
             meth = getattr(decorator, decorate_meth_name)
             meth(original_object, external_object)
 
@@ -33,7 +34,7 @@ def decorate_external_object(do_decorate, call_if_not_decorate,
         if request is not None:
             # Request specific decorating, if given, is more specific than plain object
             # decorating, so it gets to go last.
-            for decorator in registry.subscribers((original_object, request), decorate_interface):
+            for decorator in subscribers((original_object, request), decorate_interface):
                 meth = getattr(decorator, decorate_meth_name)
                 meth(original_object, external_object)
     elif call_if_not_decorate is not NotGiven and call_if_not_decorate is not None:
@@ -48,7 +49,7 @@ def decorate_external_mapping(original_object, external_object, registry, reques
         True, None,
         IExternalMappingDecorator, 'decorateExternalMapping',
         original_object, external_object,
-        registry, request
+        None, request
     )
 
 from nti.externalization._compat import import_c_accel # pylint:disable=wrong-import-position,wrong-import-order

--- a/src/nti/externalization/externalization/dictionary.py
+++ b/src/nti/externalization/externalization/dictionary.py
@@ -16,8 +16,6 @@ from __future__ import print_function
 import warnings
 
 
-from zope import component
-
 from nti.externalization._base_interfaces import make_external_dict
 from nti.externalization._base_interfaces import NotGiven
 
@@ -43,7 +41,6 @@ StandardExternalFields = get_standard_external_fields()
 def internal_to_standard_external_dictionary(
         self,
         mergeFrom=None,
-        registry=component,
         decorate=True,
         request=NotGiven,
         decorate_callback=NotGiven,
@@ -67,7 +64,8 @@ def internal_to_standard_external_dictionary(
         decorate, decorate_callback,
         IExternalMappingDecorator, 'decorateExternalMapping',
         self, result,
-        registry, request
+        None, # unused registry
+        request
     )
 
     return result
@@ -75,7 +73,7 @@ def internal_to_standard_external_dictionary(
 def to_standard_external_dictionary(
         self,
         mergeFrom=None,
-        registry=component,
+        registry=NotGiven, # Ignored
         decorate=True,
         request=NotGiven,
         decorate_callback=NotGiven,
@@ -116,7 +114,7 @@ def to_standard_external_dictionary(
       and produce a warning.
     """
 
-    if kwargs or name is not NotGiven or useCache is not NotGiven: # pragma: no cover
+    if kwargs or name is not NotGiven or useCache is not NotGiven or registry is not NotGiven: # pragma: no cover
         for _ in range(3):
             warnings.warn(
                 "Passing unused arguments to to_standard_external_dictionary will be an error",
@@ -125,7 +123,6 @@ def to_standard_external_dictionary(
     return internal_to_standard_external_dictionary(
         self,
         mergeFrom,
-        registry,
         decorate,
         request,
         decorate_callback,

--- a/src/nti/externalization/externalization/tests/test_externalizer.py
+++ b/src/nti/externalization/externalization/tests/test_externalizer.py
@@ -11,6 +11,11 @@ import unittest
 
 from zope.proxy import ProxyBase
 
+from hamcrest import assert_that
+from hamcrest import has_length
+from hamcrest import is_
+from hamcrest import same_instance
+
 from nti.externalization.externalization import to_external_object
 from ..externalizer import _obj_has_usable_externalObject
 
@@ -43,6 +48,42 @@ class TestFunctions(unittest.TestCase):
                 raise NotImplementedError
 
         self.assertFalse(_obj_has_usable_externalObject(Proxy(object())))
+
+
+    def test_calls_conform(self):
+        from nti.externalization.interfaces import IInternalObjectExternalizer
+        from nti.externalization.interfaces import INonExternalizableReplacementFactory
+
+        class Obj(object):
+            def __init__(self):
+                self.conforms = []
+
+            def __conform__(self, iface):
+                self.conforms.append(iface)
+
+        o = Obj()
+        to_external_object(o)
+
+        assert_that(o.conforms, has_length(2))
+        assert_that(o.conforms,
+                    is_([IInternalObjectExternalizer, INonExternalizableReplacementFactory]))
+
+    def test_uses_directly_provided(self):
+        from zope import interface
+        from nti.externalization.interfaces import IInternalObjectExternalizer
+
+        class Obj(object):
+            pass
+
+        o = Obj()
+        interface.directlyProvides(o, IInternalObjectExternalizer)
+        o.toExternalObject = lambda *args, **kwargs: ''
+
+        assert_that(IInternalObjectExternalizer(o, None),
+                    is_(same_instance(o)))
+
+        x = to_external_object(o)
+        assert_that(x, is_(''))
 
 
 if __name__ == '__main__':

--- a/src/nti/externalization/interfaces.py
+++ b/src/nti/externalization/interfaces.py
@@ -298,7 +298,7 @@ class INamedExternalizedObjectFactoryFinder(interface.Interface):
     updated into it.
     """
 
-    def find_factory_for_named_value(name, value, registry):
+    def find_factory_for_named_value(name, value):
         """
         Find a factory for the external object *value* when it
         is the value with the name *name*.

--- a/src/nti/externalization/internalization/_externals.pxd
+++ b/src/nti/externalization/internalization/_externals.pxd
@@ -9,4 +9,4 @@ cdef IExternalReferenceResolver
 
 # XXX: This is only public for testing
 cpdef resolve_externals(object_io, updating_object, externalObject,
-                        registry=*, context=*)
+                        context=*)

--- a/src/nti/externalization/internalization/_factories.pxd
+++ b/src/nti/externalization/internalization/_factories.pxd
@@ -11,7 +11,7 @@ cdef SEF StandardExternalFields
 # imports
 cdef component
 cdef interface
-
+cdef NotGiven
 cdef IClassObjectFactory
 cdef IExternalizedObjectFactoryFinder
 cdef IFactory

--- a/src/nti/externalization/internalization/_updater.pxd
+++ b/src/nti/externalization/internalization/_updater.pxd
@@ -5,7 +5,10 @@ from ._externals cimport resolve_externals
 from ._events cimport _notifyModified
 from ._factories cimport find_factory_for
 
+
 # imports
+cdef NotGiven
+cdef component
 cdef MutableSequence
 cdef MutableMapping
 cdef inspect
@@ -33,7 +36,6 @@ cdef dict _EMPTY_DICT
 @cython.final
 @cython.freelist(1000)
 cdef class _RecallArgs(object):
-    cdef registry
     cdef context
     cdef pre_hook
     cdef bint require_updater
@@ -54,7 +56,7 @@ cdef _invoke_updater(containedObject, externalObject, updater,
 cdef _update_sequence(externalObject, _RecallArgs args,
                       destination_name=*,
                       find_factory_for_named_value=*)
-cpdef _find_INamedExternalizedObjectFactoryFinder(containedObject, registry)
+cpdef _find_INamedExternalizedObjectFactoryFinder(containedObject)
 cdef _update_from_external_object(containedObject, externalObject, _RecallArgs args)
 
 cpdef update_from_external_object(containedObject,

--- a/src/nti/externalization/internalization/externals.py
+++ b/src/nti/externalization/internalization/externals.py
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 def resolve_externals(object_io, updating_object, externalObject,
-                      registry=component, context=None):
+                      context=None):
     # Run the resolution steps on the external object
     # TODO: Document this.
 
@@ -48,8 +48,8 @@ def resolve_externals(object_io, updating_object, externalObject,
             unwrap = True
 
         for i in range(0, len(externalObjectOid)): # pylint:disable=consider-using-enumerate
-            resolver = registry.queryMultiAdapter((updating_object, externalObjectOid[i]),
-                                                  IExternalReferenceResolver)
+            resolver = component.queryMultiAdapter((updating_object, externalObjectOid[i]),
+                                                   IExternalReferenceResolver)
             if resolver:
                 externalObjectOid[i] = resolver.resolve(externalObjectOid[i])
         if unwrap and keyPath in externalObject:  # Only put it in if it was there to start with

--- a/src/nti/externalization/internalization/factories.py
+++ b/src/nti/externalization/internalization/factories.py
@@ -16,9 +16,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 from zope import component
 from zope import interface
 
+from nti.externalization._base_interfaces import NotGiven
 from nti.externalization.interfaces import IClassObjectFactory
 from nti.externalization.interfaces import IExternalizedObjectFactoryFinder
 from nti.externalization.interfaces import IFactory
@@ -60,8 +63,7 @@ def _search_for_mime_factory(externalized_object, mime_type):
         return factory
 
     # Is there a default?
-    factory = component_queryAdapter(externalized_object,
-                                     IMimeObjectFactory)
+    factory = IMimeObjectFactory(externalized_object, None)
 
     return factory
 
@@ -139,9 +141,9 @@ def find_factory_for_class_name(class_name):
     return factory
 
 
-def find_factory_for(externalized_object, registry=component):
+def find_factory_for(externalized_object, registry=NotGiven):
     """
-    find_factory_for(externalized_object, registry=<zope.component>) -> factory
+    find_factory_for(externalized_object) -> factory
 
     Given a
     :class:`~nti.externalization.interfaces.IExternalizedObject`,
@@ -158,10 +160,18 @@ def find_factory_for(externalized_object, registry=component):
 
     Otherwise, we examine the contents of the object itself to find a
     registered factory based on MIME type (preferably) or class name.
+
+    .. versionchanged:: 1.0a10
+       The ``registry`` argument is deprecated and ignored.
     """
-    factory_finder = registry.queryAdapter(
-        externalized_object,
-        IExternalizedObjectFactoryFinder)
+    if registry is not NotGiven: # pragma: no cover
+        warnings.warn(
+            "The registry argument is deprecated and ignored",
+            FutureWarning
+        )
+
+    factory_finder = IExternalizedObjectFactoryFinder(externalized_object, None)
+
     if factory_finder is not None:
         return factory_finder.find_factory(externalized_object)
 

--- a/src/nti/externalization/internalization/tests/test_externals_wo_class_mimetype.py
+++ b/src/nti/externalization/internalization/tests/test_externals_wo_class_mimetype.py
@@ -239,7 +239,7 @@ class TestLookups(CleanUp,
         component.provideAdapter(Derived, (object,), provides=interfaces.IInternalObjectIO)
 
         with warnings.catch_warnings(record=True) as w:
-            found = updater._find_INamedExternalizedObjectFactoryFinder(self, component)
+            found = updater._find_INamedExternalizedObjectFactoryFinder(self)
 
         assert_that(found, is_(Derived))
         assert_that(w, has_length(1))

--- a/src/nti/externalization/internalization/updater.py
+++ b/src/nti/externalization/internalization/updater.py
@@ -171,8 +171,8 @@ else:
 
 class DefaultInternalObjectFactoryFinder(object):
 
-    def find_factory_for_named_value(self, name, value, registry):
-        return find_factory_for(value, registry)
+    def find_factory_for_named_value(self, name, value):
+        return find_factory_for(value)
 
 
 interface.classImplements(DefaultInternalObjectFactoryFinder, INamedExternalizedObjectFactoryFinder)
@@ -258,7 +258,7 @@ def _update_sequence(
     for index, value in enumerate(externalObject):
         if args.pre_hook is not None: # pragma: no cover
             args.pre_hook(None, value)
-        factory = find_factory_for_named_value(destination_name, value, component)
+        factory = find_factory_for_named_value(destination_name, value)
         if factory is not None:
             new_obj = _invoke_factory(factory, value)
             value = _update_from_external_object(new_obj, value, args)
@@ -356,7 +356,7 @@ def _update_from_external_object(containedObject, externalObject, args):
             # Update the sequence in-place
             _update_sequence(v, args, k, find_factory_for_named_value)
         else:
-            factory = find_factory_for_named_value(k, v, component)
+            factory = find_factory_for_named_value(k, v)
             if factory is not None:
                 new_obj = _invoke_factory(factory, v)
                 externalObject[k] = _update_from_external_object(new_obj, v, args)

--- a/src/nti/externalization/internalization/updater.py
+++ b/src/nti/externalization/internalization/updater.py
@@ -28,6 +28,7 @@ from zope import component
 from zope import interface
 
 from nti.externalization._base_interfaces import PRIMITIVES
+from nti.externalization._base_interfaces import NotGiven
 from nti.externalization.interfaces import IInternalObjectUpdater
 from nti.externalization.interfaces import IInternalObjectIO
 from nti.externalization.interfaces import INamedExternalizedObjectFactoryFinder
@@ -44,7 +45,6 @@ IPersistent_providedBy = IPersistent.providedBy
 
 class _RecallArgs(object):
     __slots__ = (
-        'registry',
         'context',
         'require_updater',
         'notify',
@@ -56,7 +56,6 @@ class _RecallArgs(object):
     # unneeded bint->object->bint conversions.
 
     def __init__(self):
-        self.registry = None
         self.context = None
         self.require_updater = False
         self.notify = True
@@ -181,7 +180,7 @@ interface.classImplements(DefaultInternalObjectFactoryFinder, INamedExternalized
 _default_factory_finder = DefaultInternalObjectFactoryFinder()
 
 def update_from_external_object(containedObject, externalObject,
-                                registry=component, context=None,
+                                registry=NotGiven, context=None,
                                 require_updater=False,
                                 notify=True,
                                 pre_hook=None):
@@ -229,8 +228,13 @@ def update_from_external_object(containedObject, externalObject,
         for i in range(3):
             warnings.warn('pre_hook is deprecated', FutureWarning, stacklevel=i)
 
+    if registry is not NotGiven: # pragma: no cover
+        warnings.warn(
+            "registry is deprecated and ignored. Call in a correct site.",
+            FutureWarning
+        )
+
     kwargs = _RecallArgs()
-    kwargs.registry = registry
     kwargs.context = context
     kwargs.require_updater = require_updater
     kwargs.notify = notify
@@ -254,7 +258,7 @@ def _update_sequence(
     for index, value in enumerate(externalObject):
         if args.pre_hook is not None: # pragma: no cover
             args.pre_hook(None, value)
-        factory = find_factory_for_named_value(destination_name, value, args.registry)
+        factory = find_factory_for_named_value(destination_name, value, component)
         if factory is not None:
             new_obj = _invoke_factory(factory, value)
             value = _update_from_external_object(new_obj, value, args)
@@ -269,7 +273,7 @@ def _invoke_updater(containedObject, externalObject,
 
     # Let the updater resolve externals
     resolve_externals(updater, containedObject, externalObject,
-                      registry=args.registry, context=args.context)
+                      context=args.context)
 
     updated = None
     # The signature may vary.
@@ -288,13 +292,13 @@ def _invoke_updater(containedObject, externalObject,
                         updater, external_keys, _EMPTY_DICT)
 
 
-def _find_INamedExternalizedObjectFactoryFinder(containedObject, registry):
-    updater = registry.queryAdapter(containedObject, INamedExternalizedObjectFactoryFinder)
+def _find_INamedExternalizedObjectFactoryFinder(containedObject):
+    updater = INamedExternalizedObjectFactoryFinder(containedObject, None)
     if updater is None:
         # Ok, check to see if an instance of the old root interface
         # InternalObjectIO is there and also provides INamedExternalizedObjectFactoryFinder;
         # if so, there's a bad ZCML registration.
-        updater = registry.queryAdapter(containedObject, IInternalObjectIO)
+        updater = IInternalObjectIO(containedObject, None)
         if INamedExternalizedObjectFactoryFinder.providedBy(updater):
             warnings.warn(
                 "The adapter %r was registered as IInternalObjectIO when it should be "
@@ -320,7 +324,6 @@ def _update_from_external_object(containedObject, externalObject, args):
     # splitting the two parts
 
     # TODO: Should the current user impact on this process?
-    __traceback_info__ = containedObject, externalObject
 
     if IPersistent_providedBy(containedObject):
         # pylint:disable=protected-access
@@ -334,10 +337,10 @@ def _update_from_external_object(containedObject, externalObject, args):
 
     assert isinstance(externalObject, MutableMapping)
 
-    factory_finder = _find_INamedExternalizedObjectFactoryFinder(containedObject, args.registry)
+    factory_finder = _find_INamedExternalizedObjectFactoryFinder(containedObject)
 
     find_factory_for_named_value = factory_finder.find_factory_for_named_value
-    __traceback_info__ += find_factory_for_named_value,
+
     # We have to save the list of keys, it's common that they get popped during the update
     # process, and then we have no descriptions to send
     external_keys = []
@@ -353,9 +356,8 @@ def _update_from_external_object(containedObject, externalObject, args):
             # Update the sequence in-place
             _update_sequence(v, args, k, find_factory_for_named_value)
         else:
-            factory = find_factory_for_named_value(k, v, args.registry)
+            factory = find_factory_for_named_value(k, v, component)
             if factory is not None:
-                __traceback_info__ += factory,
                 new_obj = _invoke_factory(factory, v)
                 externalObject[k] = _update_from_external_object(new_obj, v, args)
 
@@ -371,11 +373,10 @@ def _update_from_external_object(containedObject, externalObject, args):
         # of specificity, so we need to look up IInternalObjectUpdater,
         # not test if it's provided by what we already have.
         if args.require_updater and not isinstance(containedObject, dict):
-            get = args.registry.getAdapter
+            updater = IInternalObjectUpdater(containedObject)
         else:
-            get = args.registry.queryAdapter
+            updater = IInternalObjectUpdater(containedObject, None)
 
-        updater = get(containedObject, IInternalObjectUpdater)
 
     if updater is not None:
         _invoke_updater(containedObject, externalObject, updater, external_keys, args)

--- a/src/nti/externalization/representation.py
+++ b/src/nti/externalization/representation.py
@@ -13,6 +13,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 from ZODB.POSException import POSError
 import simplejson
 import yaml
@@ -36,7 +38,7 @@ __all__ = [
 
 
 def to_external_representation(obj, ext_format=EXT_REPR_JSON,
-                               name=_NotGiven, registry=component):
+                               name=_NotGiven, registry=_NotGiven):
     """
     to_external_representation(obj, ext_format='json', name=NotGiven) -> str
 
@@ -51,12 +53,17 @@ def to_external_representation(obj, ext_format=EXT_REPR_JSON,
         name of some other utility that implements
         `~nti.externalization.interfaces.IExternalObjectRepresenter`
     """
+    if registry is not _NotGiven: # pragma: no cover
+        warnings.warn(
+            "The registry argument is ignored. Call in a correct site.",
+            FutureWarning
+        )
     # It would seem nice to be able to do this in one step during
     # the externalization process itself, but we would wind up traversing
     # parts of the datastructure more than necessary. Here we traverse
     # the whole thing exactly twice.
-    ext = toExternalObject(obj, name=name, registry=registry)
-    return registry.getUtility(IExternalObjectRepresenter, name=ext_format).dump(ext)
+    ext = toExternalObject(obj, name=name)
+    return component.getUtility(IExternalObjectRepresenter, name=ext_format).dump(ext)
 
 
 def to_json_representation(obj):

--- a/src/nti/externalization/tests/test_datastructures.py
+++ b/src/nti/externalization/tests/test_datastructures.py
@@ -469,20 +469,20 @@ class TestInterfaceObjectIO(CleanUp,
         inst = self._makeOne(O(), iface_upper_bound=I)
 
         # Key not in schema: not an error (XXX should it be?)
-        assert_that(inst.find_factory_for_named_value('missing', {}, component),
+        assert_that(inst.find_factory_for_named_value('missing', {}),
                     is_(none()))
 
         # object that's not-string: not an error (XXX: should it be? we don't
         # test for 'callable' for performance)
         I['field'].setTaggedValue('__external_factory__', self)
 
-        assert_that(inst.find_factory_for_named_value('field', {}, component),
+        assert_that(inst.find_factory_for_named_value('field', {}),
                     is_(self))
 
         # string object is looked up as a utility
         I['field'].setTaggedValue('__external_factory__', 'some factory')
         with self.assertRaises(component.ComponentLookupError):
-            inst.find_factory_for_named_value('field', {}, component)
+            inst.find_factory_for_named_value('field', {})
 
     def test_no_factory_for_dict_with_no_types(self):
         from zope.schema import Dict
@@ -496,7 +496,7 @@ class TestInterfaceObjectIO(CleanUp,
             pass
 
         inst = self._makeOne(O(), iface_upper_bound=I)
-        factory = inst.find_factory_for_named_value('field', {}, component)
+        factory = inst.find_factory_for_named_value('field', {})
         assert_that(factory, is_(none()))
 
     def test_no_factory_for_dict_with_non_object_value(self):
@@ -515,7 +515,7 @@ class TestInterfaceObjectIO(CleanUp,
             pass
 
         inst = self._makeOne(O(), iface_upper_bound=I)
-        factory = inst.find_factory_for_named_value('field', {}, component)
+        factory = inst.find_factory_for_named_value('field', {})
         assert_that(factory, is_(none()))
 
     def test_factory_for_dict_with_object_value(self):
@@ -537,7 +537,7 @@ class TestInterfaceObjectIO(CleanUp,
             pass
 
         inst = self._makeOne(O(), iface_upper_bound=I)
-        factory = inst.find_factory_for_named_value('field', {}, component)
+        factory = inst.find_factory_for_named_value('field', {})
         assert_that(factory, is_not(none()))
 
 

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -179,10 +179,10 @@ class TestFunctions(ExternalizationLayerTest):
         gsm.unregisterAdapter(factory=DevmodeNonExternalizableObjectReplacementFactory,
                               required=(interface.Interface,))
 
-        assert_that(toExternalObject(Broken(), registry=gsm),
+        assert_that(toExternalObject(Broken()),
                     has_entry("Class", "NonExternalizableObject"))
 
-        assert_that(toExternalObject([Broken()], registry=gsm),
+        assert_that(toExternalObject([Broken()]),
                     has_items(has_entry("Class", "NonExternalizableObject")))
 
     def test_catching_component(self):

--- a/src/nti/externalization/tests/test_internalization.py
+++ b/src/nti/externalization/tests/test_internalization.py
@@ -56,8 +56,10 @@ class TestEvents(CleanUp,
         from nti.externalization.internalization import notifyModified
         from nti.externalization.interfaces import ObjectModifiedFromExternalEvent
 
-        event = notifyModified(*args, **kwargs)
+        with warnings.catch_warnings(record=True):
+            event = notifyModified(*args, **kwargs)
         self.assertIsInstance(event, ObjectModifiedFromExternalEvent)
+
         return event
 
     def test_notify_event_kwargs(self):
@@ -379,7 +381,7 @@ class TestUpdateFromExternaObject(CleanUp,
 
     def test_update_empty_mapping_with_required_updater(self):
         ext = {}
-        with self.assertRaises(LookupError):
+        with self.assertRaises(TypeError):
             self._callFUT(self, ext, require_updater=True)
 
     def test_update_mapping_of_primitives_and_sequences(self):


### PR DESCRIPTION
Instead, directly call the interface we need to adapt from where possible. (Where not possible, use the component APIs so we are consistent.) The user is responsible for making sure the correct site is active now.

This lets things like `interface.directlyProvide(obj, IInternalObjectExternalizer)` work. Plus it checks out as slightly faster.