### PR TITLE
Require zope.interface 5.0, and use it to handle inheriting/not inhering tagged values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@
 1.0.0a15 (unreleased)
 =====================
 
-- Add compatibility with zope.interface 5.0.
+- Add compatibility with, and require, zope.interface 5.0.
+
+- Document which tagged values are inherited and which are not.
+
+- Stop inheriting ``_ext_is_marker_interface``.
 
 
 1.0.0a14 (2019-11-13)

--- a/docs/special_attributes.rst
+++ b/docs/special_attributes.rst
@@ -6,14 +6,19 @@ This document covers some of the special attributes used by this
 module.
 
 When we discuss interfaces or the contents of attributes, we are
-referring to `tagged values <zope.interface.taggedValue>`.
+referring to `tagged values <zope.interface.taggedValue>`. Unless
+otherwise noted, tagged values must be set directly on the object in
+question; they are not inherited from parent objects.
 
 * ``__external_class_name__``
 
 Used an a class or interface to determine the value of the ``Class``
 standard external value. Usually this is a string, but when using
 `.InterfaceObjectIO` (including ``ext:registerAutoPackageIO``) it can
-be a callable.
+be a callable returning a string or ``None``
+
+This value is inherited; the first non-None value in the resolution
+order will be used (the distinction matters when using callables).
 
 .. seealso:: `.AutoPackageSearchingScopedInterfaceObjectIO._ap_compute_external_class_name_from_interface_and_instance`
    and `.AutoPackageSearchingScopedInterfaceObjectIO._ap_find_factories`
@@ -52,4 +57,15 @@ factories discovered by ``ext:registerAutoPackageIO`` holding the
 primary factory discovered for that interface. Used when internalizing
 anonymous external data.
 
+This value is inherited.
+
 .. versionadded:: 1.0a8
+
+* ``__external_accept_id__``
+
+For attributes. Documentation needed.
+
+* ``_ext_is_marker_interface``
+
+When searching for a schema to use for externalization, interfaces
+with this tagged value directly set will not be considered.

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(
         'zope.dublincore',
         'zope.event',
         'zope.hookable >= 4.2.0',
-        'zope.interface',
+        'zope.interface >= 5.0.0', # getDirectTaggedValue
         'zope.intid',
         'zope.lifecycleevent',
         'zope.location',
@@ -210,7 +210,7 @@ setup(
             'sphinx_rtd_theme',
         ],
         'benchmarks': [
-            'perf',
+            'pyperf',
         ],
     },
     entry_points=entry_points,

--- a/src/nti/externalization/autopackage.py
+++ b/src/nti/externalization/autopackage.py
@@ -13,7 +13,6 @@ from ZODB.loglevels import TRACE
 from zope import interface
 
 from zope.dottedname import resolve as dottedname
-from zope.interface.interface import Element
 from zope.mimetype.interfaces import IContentTypeAware
 
 from nti.schema.interfaces import find_most_derived_interface
@@ -63,7 +62,7 @@ class AutoPackageSearchingScopedInterfaceObjectIO(ModuleScopedInterfaceObjectIO)
         #
         # _ap_find_potential_factories_in_module() solves a related problem
         # when class aliases were being used.
-        return Element.queryTaggedValue(iface, name)
+        return iface.queryDirectTaggedValue(name)
 
     @classmethod
     def _ap_compute_external_class_name_from_interface_and_instance(cls, unused_iface, impl):

--- a/src/nti/externalization/tests/test_zcml.py
+++ b/src/nti/externalization/tests/test_zcml.py
@@ -374,9 +374,9 @@ class TestAnonymousObjectFactoryZCML(PlacelessSetup,
 
         xmlconfig.string(self.SCAN_THIS_MODULE)
 
-        assert_that(ISchema['field'].getTaggedValue('__external_factory__'),
+        assert_that(ISchema['field'].getDirectTaggedValue('__external_factory__'),
                     is_('nti.externalization.tests.test_zcml.ISchema:field'))
-        assert_that(ISchema['field2'].getTaggedValue('__external_factory__'),
+        assert_that(ISchema['field2'].getDirectTaggedValue('__external_factory__'),
                     is_('nti.externalization.tests.test_zcml.ISchema:field2'))
 
     def test_scan_no_create(self):


### PR DESCRIPTION
In particular, _ext_is_marker_interface is not inherited.