### PR TITLE
Better externalization of numbers.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,4 +9,5 @@ exclude_lines =
     pragma: no cover
     raise NotImplementedError
     raise AssertionError
+    Python 2
     if __name__ == .__main__.:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,15 @@
 =========
 
 
-1.0.1 (unreleased)
+1.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make instances of ``fractions.Fraction`` externalize as a string
+  such as ``"1/3"``. When received by a schema field that can parse
+  this format, such as ``zope.schema.Rational`` (or higher on the
+  numeric tower), this means fractions can be round-tripped.
+- Support externalizing ``decimal.Decimal`` objects in the YAML
+  representation.
 
 
 1.0.0 (2020-03-19)

--- a/src/nti/externalization/configure.zcml
+++ b/src/nti/externalization/configure.zcml
@@ -40,6 +40,9 @@
     <utility factory=".representation.JsonRepresenter" />
     <utility factory=".representation.YamlRepresenter" />
 
+    <!-- -->
+    <!-- Dates and datetimes -->
+    <!-- -->
     <!-- Offer to adapt strings to dates -->
     <!-- TODO: This is a bit ad-hoc. Surely there's a more formal set
     of transforms somewhere? -->
@@ -49,11 +52,20 @@
     <adapter factory=".datetime.datetime_from_timestamp" for="int" />
     <adapter factory=".datetime.datetime_from_timestamp" for="float" />
 
-    <!-- Do the reverse as well.-->
+    <!-- Do the reverse as well. -->
     <adapter factory=".datetime.date_to_string" />
     <adapter factory=".datetime.datetime_to_string" />
     <adapter factory=".datetime.duration_to_string" />
 
+    <!-- -->
+    <!-- Numbers (fractions) -->
+    <!-- -->
+    <!-- Anything not represented directly goes out as a string. -->
+    <adapter factory=".numbers.second_chance_number_externalizer" />
+
+    <!-- -->
+    <!-- Object factories -->
+    <!-- -->
     <adapter for="*"
              factory=".internalization.default_externalized_object_factory_finder_factory"
              provides=".interfaces.IExternalizedObjectFactoryFinder" />

--- a/src/nti/externalization/externalization/externalizer.py
+++ b/src/nti/externalization/externalization/externalizer.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import warnings
 try:
     from collections.abc import Set
-except ImportError:
+except ImportError: # Python 2
     from collections import Set
     from collections import Mapping
 else: # pragma: no cover
@@ -360,10 +360,11 @@ def to_external_object(
     :param decorate_callback: Callable to be invoked in case there is
         no decaration
     """
-
     # Catch the primitives up here, quickly. This catches
-    # numbers, strings, and None
-    if isinstance(obj, PRIMITIVES):
+    # numbers, strings, and None. Only do this if we're not on the
+    # second-pass fallback; that means that some representer couldn't handle
+    # a primitive natively (usually a decimal)
+    if name != 'second-pass' and isinstance(obj, PRIMITIVES):
         return obj
 
     manager_top = _manager_get() # (name, memos)

--- a/src/nti/externalization/internalization/externals.py
+++ b/src/nti/externalization/internalization/externals.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 # stdlib imports
 try:
     from collections.abc import MutableSequence
-except ImportError:
+except ImportError: # Python 2
     from collections import MutableSequence
 
 

--- a/src/nti/externalization/internalization/fields.py
+++ b/src/nti/externalization/internalization/fields.py
@@ -348,7 +348,7 @@ def validate_named_field_value(self, iface, field_name, value):
 def _as_native_str(s):
     if isinstance(s, str):
         return s
-    return s.encode('ascii')
+    return s.encode('ascii') # Python 2
 
 
 from nti.externalization._compat import import_c_accel # pylint:disable=wrong-import-position,wrong-import-order

--- a/src/nti/externalization/internalization/updater.py
+++ b/src/nti/externalization/internalization/updater.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 # stdlib imports
 try:
     from collections.abc import MutableSequence
-except ImportError:
+except ImportError: # Python 2
     from collections import MutableSequence
     from collections import MutableMapping
 else: # pragma: no cover
@@ -90,11 +90,11 @@ def _get_update_signature(updater):
     if spec is None:
         try:
             func = updater.updateFromExternalObject
-            if hasattr(inspect, 'getfullargspec'): # pragma: no cover
+            if hasattr(inspect, 'getfullargspec'):
                 # Python 3. getargspec() is deprecated.
                 argspec = inspect.getfullargspec(func) # pylint:disable=no-member
                 keywords = argspec.varkw
-            else:
+            else: # Python 2
                 argspec = inspect.getargspec(func)
                 keywords = argspec.keywords
             args = argspec.args

--- a/src/nti/externalization/numbers.py
+++ b/src/nti/externalization/numbers.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+Support for externalizing arbitrary numbers.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import fractions
+import decimal
+
+from zope import interface
+from zope import component
+from zope.interface.common.numbers import INumber
+from zope.interface.common.numbers import IRational
+
+from nti.externalization.interfaces import IInternalObjectExternalizer
+
+
+@interface.implementer(IInternalObjectExternalizer)
+@component.adapter(INumber)
+class second_chance_number_externalizer(object):
+    def __init__(self, context):
+        self.context = context
+
+    def toExternalObject(self, **unused_kwargs):
+        return str(self.context)
+
+# Depending on the order of imports, these may or may not have
+# been declared already.
+if not IRational.providedBy(fractions.Fraction('1/3')): # pragma: no cover
+    interface.classImplements(fractions.Fraction, IRational)
+
+if not INumber.providedBy(decimal.Decimal('1')): # pragma: no cover
+    # NOT an IReal; see notes in stdlib numbers.py for why.
+    interface.classImplements(decimal.Decimal, INumber)
+
+assert IRational.providedBy(fractions.Fraction('1/3'))
+assert INumber.providedBy(decimal.Decimal('1'))

--- a/src/nti/externalization/persistence.py
+++ b/src/nti/externalization/persistence.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 # stdlib imports
 try:
     from collections.abc import Sequence
-except ImportError:
+except ImportError: # Python 2
     from collections import Sequence
 
 try:

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -67,8 +67,8 @@ from hamcrest import has_property as has_attr
 
 try:
     from collections import UserDict
-except ImportError:
-    from UserDict import UserDict # Python 2
+except ImportError: # Python 2
+    from UserDict import UserDict
 
 
 # disable: accessing protected members, too many methods

--- a/src/nti/externalization/tests/test_persistence.py
+++ b/src/nti/externalization/tests/test_persistence.py
@@ -247,7 +247,7 @@ class TestNoPickle(unittest.TestCase):
         except ImportError: # pragma: no cover
             # Python 3
             raise TypeError("Not allowed to pickle")
-        else:
+        else: # pragma: no cover
             cPickle.dumps(obj)
 
     def _all_persists_fail(self, factory):

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
    py27,py27-pure,py36,py36-pure,py37,py38,pypy,pypy3,coverage,docs
 
 [testenv]
+usedevelop = true
 commands =
     zope-testrunner --test-path=src []
 deps =
@@ -24,9 +25,10 @@ setenv =
 [testenv:coverage]
 usedevelop = true
 basepython =
-    python2.7
+    python3
 commands =
     coverage run -m zope.testrunner --test-path=src
+    coverage html -i
     coverage report --fail-under=100
 deps =
     {[testenv]deps}


### PR DESCRIPTION
numbers.Number instances aren't guaranteed to be externalizable, so don't treat them that way (as primitives). Only list as primitives those types that we're sure about. The rest need to be registered.

Do so for fractions.Fraction and decimal.Decimal for both JSON and YAML.