### PR TITLE
Add standard basic externalizer and rename IExternalMappingDecorator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Test
       run: |
         coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+        PURE_PYTHON=1 coverage run -a -m zope.testrunner --test-path=src  --auto-color --auto-progress
     - name: Sphinx DocTests
       if: matrix.python-version != 2.7 && matrix.python-version != 'pypy2'
       # These do still run on Python 2 (test_docs.py) but they need an output normalizer,
@@ -44,6 +45,7 @@ jobs:
       # but that seems like overkill
       run: |
         coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
+        PURE_PYTHON=1 coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
 
     - name: Submit to Coveralls
       # This is a container action, which only runs on Linux.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
       # TODO: Revisit this when we have caching of that part.
       run: |
         pip install -U -e .[lint]
-        python -m pylint --limit-inference-results=1 --rcfile=.pylintrc nti.externalization
+        python -m pylint --rcfile=.pylintrc nti.externalization
 
   coveralls_finish:
     needs: test

--- a/docs/api/interfaces.rst
+++ b/docs/api/interfaces.rst
@@ -12,3 +12,12 @@
    :member-order: bysource
 .. autoclass:: nti.externalization._base_interfaces.StandardInternalFields
 .. autodata:: nti.externalization._base_interfaces.DEFAULT_EXTERNALIZATION_POLICY
+
+Deprecated Names
+================
+
+.. autodata:: nti.externalization.interfaces.IList
+.. autodata:: nti.externalization.interfaces.IIterable
+.. autodata:: nti.externalization.interfaces.IExternalObject
+.. autodata:: nti.externalization.interfaces.INonExternalizableReplacer
+.. autodata:: nti.externalization.interfaces.IExternalMappingDecorator

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -183,7 +183,9 @@ Now we will write an ``IInternalObjectIO`` adapter for it:
    @adapter(InternalObject)
    class InternalObjectIO(StandardInternalObjectExternalizer):
        def __init__(self, context):
-           self.context = context
+           super().__init__(context)
+           # Setting this is optional, if we don't like the default
+           self.__external_class_name__ = 'ExternalObject'
 
        def toExternalObject(self, **kwargs):
           result = super(InternalObjectIO, self).toExternalObject(**kwargs)
@@ -228,12 +230,12 @@ Because we don't have a Python package to put this ZCML in, we'll
 register it manually.
 
   >>> from zope import component
-  >>> component.provideAdapter(InternalObjectIO)
+  >>> component.provideAdapter(InternalObjectIO, provides=IInternalObjectIO)
   >>> internal = InternalObject('original')
   >>> internal
   <InternalObject 'original' letter='a' number=42>
   >>> pprint(to_external_object(internal))
-  {'Class': 'InternalObject', 'Letter': 'a', 'Number': 42}
+  {'Class': 'ExternalObject', 'Letter': 'a', 'Number': 42}
   >>> update_from_external_object(internal, {'Letter': 'b', 'Number': 3})
   <InternalObject 'original' letter='b' number=3>
 
@@ -247,7 +249,7 @@ others:
   >>> internal.creator = u'sjohnson'
   >>> internal.createdTime = 123456
   >>> pprint(to_external_object(internal))
-  {'Class': 'InternalObject',
+  {'Class': 'ExternalObject',
    'CreatedTime': 123456,
    'Creator': 'sjohnson',
    'Letter': 'b',

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -237,6 +237,29 @@ register it manually.
   >>> update_from_external_object(internal, {'Letter': 'b', 'Number': 3})
   <InternalObject 'original' letter='b' number=3>
 
+Notice that the external form included the ``Class`` key; this is one
+of the `~._base_interfaces.StandardExternalFields`
+automatically recognized by the built-in externalizers, whose value is
+taken from the corresponding key named in
+`~._base_interfaces.StandardInternalFields`. There are
+others:
+
+  >>> internal.creator = u'sjohnson'
+  >>> internal.createdTime = 123456
+  >>> pprint(to_external_object(internal))
+  {'Class': 'InternalObject',
+   'CreatedTime': 123456,
+   'Creator': 'sjohnson',
+   'Letter': 'b',
+   'Number': 3}
+
+.. note:: Notice how the names of the internal fields, ``creator`` and
+          ``createdTime`` because ``Creator`` and ``CreatedTime`` in
+          the external object. The convention used by this library is
+          that fields that cannot be modified directly by the client
+          are always capitalized. Your custom externalizers and
+          interface definitions should follow this convention.
+
 By using adapters like this, we can separate out externalization from
 our core logic. Of course, that's still a lot of manual code to write.
 

--- a/docs/externalization.rst
+++ b/docs/externalization.rst
@@ -125,11 +125,11 @@ look for a request):
     'full_name': 'Steve Jobs',
     'href': 'http://example.com/path/address'}
 
-IExternalMappingDecorator
--------------------------
+IExternalStandardDictionaryDecorator
+------------------------------------
 
 There is also
-`~nti.externalization.interfaces.IExternalMappingDecorator`. It is
+`~nti.externalization.interfaces.IExternalStandardDictionaryDecorator`. It is
 called by `.to_standard_external_dictionary`. Typically that's *well
 before* most of the object-specific fields have been filled in (e.g.,
 from the object schema), and it is always before

--- a/src/nti/externalization/_datastructures.pxd
+++ b/src/nti/externalization/_datastructures.pxd
@@ -44,7 +44,9 @@ cdef class ExternalizableDictionaryMixin(object):
     pass
 
 cdef class StandardInternalObjectExternalizer(ExternalizableDictionaryMixin):
-    pass
+    cdef public context
+    cdef public bint __external_can_create__
+    cdef public str __external_class_name__
 
 cdef class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
     cpdef _ext_replacement(self)

--- a/src/nti/externalization/_datastructures.pxd
+++ b/src/nti/externalization/_datastructures.pxd
@@ -43,6 +43,9 @@ cdef class ExternalizableDictionaryMixin(object):
     # cpdef ivars/methods) without causing metaclass problems.
     pass
 
+cdef class StandardInternalObjectExternalizer(ExternalizableDictionaryMixin):
+    pass
+
 cdef class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
     cpdef _ext_replacement(self)
     cpdef frozenset _ext_all_possible_keys(self)

--- a/src/nti/externalization/configure.zcml
+++ b/src/nti/externalization/configure.zcml
@@ -13,11 +13,11 @@
     -->
     <include package="." file="meta.zcml" />
 
-    <subscriber provides=".interfaces.IExternalMappingDecorator"
+    <subscriber provides=".interfaces.IExternalStandardDictionaryDecorator"
                 for="zope.dublincore.interfaces.IDCExtended"
                 factory=".dublincore.DCExtendedExternalMappingDecorator" />
 
-    <subscriber provides=".interfaces.IExternalMappingDecorator"
+    <subscriber provides=".interfaces.IExternalStandardDictionaryDecorator"
                 for="zope.dublincore.interfaces.IDCDescriptiveProperties"
                 factory=".dublincore.DCDescriptivePropertiesExternalMappingDecorator" />
 
@@ -33,7 +33,7 @@
              provides=".interfaces.ILocatedExternalSequence"
              factory=".interfaces.LocatedExternalList" />
 
-    <adapter for=".interfaces.IList"
+    <adapter for="zope.interface.common.builtins.IList"
              provides=".interfaces.ILocatedExternalSequence"
              factory=".interfaces.LocatedExternalList" />
 

--- a/src/nti/externalization/datastructures.py
+++ b/src/nti/externalization/datastructures.py
@@ -60,6 +60,7 @@ IObject_providedBy = IObject.providedBy
 
 __all__ = [
     'ExternalizableDictionaryMixin',
+    'StandardInternalObjectExternalizer',
     'AbstractDynamicObjectIO',
     'ExternalizableInstanceDict',
     'InterfaceObjectIO',
@@ -106,6 +107,33 @@ class ExternalizableDictionaryMixin(object):
         return self._ext_standard_external_dictionary(self._ext_replacement(),
                                                       mergeFrom=mergeFrom,
                                                       **kwargs)
+
+
+class StandardInternalObjectExternalizer(ExternalizableDictionaryMixin):
+    """
+    An adapter that can be used to implement
+    :class:`~nti.externalization.interfaces.IInternalObjectExternalizer`.
+
+    The result of externalizing is the standard external dictionary.
+
+    This can be registered as-is, or subclassed to add additional
+    items in the external dictionary. In that case, always begin by
+    calling this implemention first and updating the result.
+
+    .. versionadded:: 2.3.0
+    """
+
+    def __init__(self, context):
+        self.context = context
+
+    def _ext_replacement(self):
+        """
+        Returns this adapter's *context* argument.
+        """
+        return self.context
+
+    def toExternalObject(self, **kwargs):
+        return self.toExternalDictionary(**kwargs)
 
 
 class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):

--- a/src/nti/externalization/datastructures.py
+++ b/src/nti/externalization/datastructures.py
@@ -111,10 +111,11 @@ class ExternalizableDictionaryMixin(object):
 
 class StandardInternalObjectExternalizer(ExternalizableDictionaryMixin):
     """
-    An adapter that can be used to implement
+    An *adapter* that can be used to implement
     :class:`~nti.externalization.interfaces.IInternalObjectExternalizer`.
 
-    The result of externalizing is the standard external dictionary.
+    The result of externalizing is the standard external dictionary
+    for this adapter's *context* argument.
 
     This can be registered as-is, or subclassed to add additional
     items in the external dictionary. In that case, always begin by
@@ -197,7 +198,7 @@ class AbstractDynamicObjectIO(ExternalizableDictionaryMixin):
 
     def _ext_all_possible_keys(self):
         """
-        This method must return a frozenset of native strings.
+        This method must return a `frozenset` of native strings.
         """
         raise NotImplementedError()
 

--- a/src/nti/externalization/dublincore.py
+++ b/src/nti/externalization/dublincore.py
@@ -23,7 +23,7 @@ from zope import interface
 from zope.dublincore.interfaces import IDCDescriptiveProperties
 from zope.dublincore.interfaces import IDCExtended
 
-from nti.externalization.interfaces import IExternalMappingDecorator
+from nti.externalization.interfaces import IExternalStandardDictionaryDecorator
 from nti.externalization.interfaces import StandardExternalFields
 from nti.externalization.singleton import Singleton
 
@@ -36,7 +36,7 @@ __all__ = [
 # but only provide a subset of the properties. (mostly due to programming errors).
 # Hence the use of getattr below, to protect against this.
 @component.adapter(IDCExtended)
-@interface.implementer(IExternalMappingDecorator)
+@interface.implementer(IExternalStandardDictionaryDecorator)
 class DCExtendedExternalMappingDecorator(Singleton):
     """
     Adds the extended properties of dublincore to external objects as
@@ -48,7 +48,7 @@ class DCExtendedExternalMappingDecorator(Singleton):
         only field that ever gets populated.
 
     Implements
-    `~nti.externalization.interfaces.IExternalMappingDecorator` for
+    `~nti.externalization.interfaces.IExternalStandardDictionaryDecorator` for
     :class:`zope.dublincore.interfaces.IDCExtended` objects.
     """
 
@@ -61,14 +61,14 @@ class DCExtendedExternalMappingDecorator(Singleton):
 
 
 @component.adapter(IDCDescriptiveProperties)
-@interface.implementer(IExternalMappingDecorator)
+@interface.implementer(IExternalStandardDictionaryDecorator)
 class DCDescriptivePropertiesExternalMappingDecorator(Singleton):
     """
     Supports the 'DCTitle' and 'DCDescription' fields, as defined in
     :class:`zope.dublincore.interfaces.IDCDescriptiveProperties`.
 
     Implements
-    `~nti.externalization.interfaces.IExternalMappingDecorator`.
+    `~nti.externalization.interfaces.IExternalStandardDictionaryDecorator`.
     """
 
     def decorateExternalMapping(self, original, external):

--- a/src/nti/externalization/externalization/_decorate.pxd
+++ b/src/nti/externalization/externalization/_decorate.pxd
@@ -1,6 +1,6 @@
 cdef get_current_request
 cdef NotGiven
-cdef IExternalMappingDecorator
+cdef IExternalStandardDictionaryDecorator
 cdef subscribers
 
 cpdef decorate_external_object(bint do_decorate, call_if_not_decorate,

--- a/src/nti/externalization/externalization/_dictionary.pxd
+++ b/src/nti/externalization/externalization/_dictionary.pxd
@@ -26,7 +26,7 @@ cdef component
 
 
 cdef set_external_identifiers
-cdef IExternalMappingDecorator
+cdef IExternalStandardDictionaryDecorator
 
 cdef NotGiven
 

--- a/src/nti/externalization/externalization/_externalizer.pxd
+++ b/src/nti/externalization/externalization/_externalizer.pxd
@@ -21,7 +21,7 @@ cdef IFiniteSequence
 cdef ThreadLocalManager
 cdef get_current_request
 cdef set_external_identifiers
-cdef IExternalMappingDecorator
+cdef IExternalStandardDictionaryDecorator
 cdef IExternalObject
 cdef IExternalObjectDecorator
 cdef ILocatedExternalSequence

--- a/src/nti/externalization/externalization/decorate.py
+++ b/src/nti/externalization/externalization/decorate.py
@@ -15,7 +15,7 @@ from zope.component import subscribers
 
 from nti.externalization.extension_points import get_current_request
 from nti.externalization._base_interfaces import NotGiven
-from nti.externalization.interfaces import IExternalMappingDecorator
+from nti.externalization.interfaces import IExternalStandardDictionaryDecorator
 
 
 def decorate_external_object(do_decorate, call_if_not_decorate,
@@ -50,7 +50,7 @@ def decorate_external_mapping(original_object,
     # A convenience API exposed to Python in __init__.py
     return decorate_external_object(
         True, None,
-        IExternalMappingDecorator, 'decorateExternalMapping',
+        IExternalStandardDictionaryDecorator, 'decorateExternalMapping',
         original_object, external_object,
         None, request
     )

--- a/src/nti/externalization/externalization/dictionary.py
+++ b/src/nti/externalization/externalization/dictionary.py
@@ -21,7 +21,7 @@ from nti.externalization._base_interfaces import NotGiven
 
 
 from nti.externalization.extension_points import set_external_identifiers
-from nti.externalization.interfaces import IExternalMappingDecorator
+from nti.externalization.interfaces import IExternalStandardDictionaryDecorator
 
 
 from nti.externalization._base_interfaces import get_standard_external_fields
@@ -64,7 +64,7 @@ def internal_to_standard_external_dictionary(
 
     decorate_external_object(
         decorate, decorate_callback,
-        IExternalMappingDecorator, 'decorateExternalMapping',
+        IExternalStandardDictionaryDecorator, 'decorateExternalMapping',
         self, result,
         None, # unused registry
         request
@@ -88,7 +88,7 @@ def to_standard_external_dictionary(
     """to_standard_external_dictionary(self, mergeFrom=None, decorate=True, request=NotGiven)
 
     Returns a dictionary representing the standard externalization of
-    the object. This function takes care of many of the standard external fields:
+    the object *self*. This function takes care of many of the standard external fields:
 
     * External identifiers like `.StandardExternalFields.OID` and `.StandardExternalFields.NTIID`
       using `.set_external_identifiers`.
@@ -100,24 +100,34 @@ def to_standard_external_dictionary(
       (from the ``mimeType`` attribute of the object).
 
     If the object has any
-    :class:`~nti.externalization.interfaces.IExternalMappingDecorator`
+    :class:`~nti.externalization.interfaces.IExternalStandardDictionaryDecorator`
     subscribers registered for it, they will be called to decorate the
     result of this method before it returns (**unless** *decorate* is
-    set to False; only do this if you know what you are doing! )
+    set to `False`; only do this if you know what you are doing! )
+    This is the only part of :mod:`nti.externalization` that invokes this
+    decorator.
 
-    :keyword dict mergeFrom:
-        For convenience, if *mergeFrom* is not
-        None, then those values will be added to the dictionary
-        created by this method. The keys and values in *mergeFrom*
-        should already be external.
-    :keyword ExternalizationPolicy policy: The :class:`~.ExternalizationPolicy` to
-        use. Must not be None.
-    :returns: A `.LocatedExternalDict`.
+    Custom externalization should begin by calling this function, or,
+    preferably, by using an existing externalizer (which invokes this
+    function, such as :class:`~.StandardInternalObjectExternalizer` or
+    :class:`~.InterfaceObjectIO` ) or subclassing such an existing
+    type and mutating the dictionary returned from super's
+    ``toExternalObject`` in your own implementation.
+
+   :keyword dict mergeFrom: For convenience, if *mergeFrom* is not
+       `None`, then values it contains will be added to the dictionary
+       created by this method. The keys and values in *mergeFrom*
+       should already be external.
+   :type mergeFrom: dict
+   :keyword ExternalizationPolicy policy: The :class:`~.ExternalizationPolicy` to
+       use. Must not be None.
+   :returns: A `.LocatedExternalDict`. For further externalization,
+       this object should be mutated in place.
 
    .. versionchanged:: 1.0a1
       Arbitrary keyword arguments not used by this function are deprecated
       and produce a warning.
-    .. versionchanged:: 2.1
+   .. versionchanged:: 2.1
        Add the *policy* keyword.
     """
 

--- a/src/nti/externalization/persistence.py
+++ b/src/nti/externalization/persistence.py
@@ -37,7 +37,7 @@ from zope import interface
 
 from nti.externalization.datastructures import ExternalizableDictionaryMixin
 from nti.externalization.externalization import toExternalObject
-from nti.externalization.interfaces import IExternalObject
+from nti.externalization.interfaces import IInternalObjectExternalizer
 from nti.externalization.oids import toExternalOID
 from nti.externalization.proxy import removeAllProxies
 
@@ -114,7 +114,7 @@ def _weakRef_toExternalObject(self):
     return toExternalObject(val) if val is not None else None
 
 PWeakRef.toExternalObject = _weakRef_toExternalObject
-interface.classImplements(PWeakRef, IExternalObject)
+interface.classImplements(PWeakRef, IInternalObjectExternalizer)
 
 
 def _weakRef_toExternalOID(self):

--- a/src/nti/externalization/tests/test_datastructures.py
+++ b/src/nti/externalization/tests/test_datastructures.py
@@ -16,6 +16,7 @@ from nti.externalization.tests import ExternalizationLayerTest
 
 from nti.testing.matchers import is_false
 from nti.testing.matchers import is_true
+from nti.testing.matchers import verifiably_provides
 
 from hamcrest import assert_that
 from hamcrest import has_property
@@ -756,3 +757,46 @@ class TestExternalizableInstanceDict(CommonTestMixin,
 
         # And marked as changed
         assert_that(m, has_property('_p_changed', True))
+
+
+class TestStandardInternalObjectExternalizer(unittest.TestCase):
+
+    def test_provides(self):
+        from nti.externalization.interfaces import IInternalObjectExternalizer
+        from nti.externalization.datastructures import StandardInternalObjectExternalizer
+        o = StandardInternalObjectExternalizer(object())
+        assert_that(o, verifiably_provides(IInternalObjectExternalizer))
+
+    def test_subclass(self):
+        from nti.externalization.interfaces import IInternalObjectExternalizer
+        from nti.externalization.datastructures import StandardInternalObjectExternalizer
+
+        class X(StandardInternalObjectExternalizer):
+            def __init__(self, context):
+                StandardInternalObjectExternalizer.__init__(self, context)
+                self.__external_class_name__ = 'Foo'
+
+        class Ext(object):
+            creator = 'sjohnson'
+
+        o = X(Ext())
+        assert_that(o, verifiably_provides(IInternalObjectExternalizer))
+
+        ext = o.toExternalObject()
+        assert_that(ext, is_({
+            'Class': 'Foo',
+            'Creator': 'sjohnson',
+        }))
+
+        # Now non-native-strs
+        ext = Ext()
+        ext.creator = u'sjohnson'
+        with self.assertRaises(TypeError):
+            o.__external_class_name__ = u'Foo' if bytes is str else b'Foo'
+        o.context = ext
+
+        ext = o.toExternalObject()
+        assert_that(ext, is_({
+            'Class': 'Foo',
+            'Creator': 'sjohnson',
+        }))

--- a/src/nti/externalization/tests/test_datastructures.py
+++ b/src/nti/externalization/tests/test_datastructures.py
@@ -770,6 +770,7 @@ class TestStandardInternalObjectExternalizer(unittest.TestCase):
     def test_subclass(self):
         from nti.externalization.interfaces import IInternalObjectExternalizer
         from nti.externalization.datastructures import StandardInternalObjectExternalizer
+        from nti.externalization._compat import PURE_PYTHON
 
         class X(StandardInternalObjectExternalizer):
             def __init__(self, context):
@@ -791,9 +792,12 @@ class TestStandardInternalObjectExternalizer(unittest.TestCase):
         # Now non-native-strs
         ext = Ext()
         ext.creator = u'sjohnson'
-        with self.assertRaises(TypeError):
-            o.__external_class_name__ = u'Foo' if bytes is str else b'Foo'
         o.context = ext
+
+        if not PURE_PYTHON:
+            # XXX: pure-python mode allows anything.
+            with self.assertRaises(TypeError):
+                o.__external_class_name__ = u'Foo' if bytes is str else b'Foo'
 
         ext = o.toExternalObject()
         assert_that(ext, is_({

--- a/src/nti/externalization/tests/test_externalization.py
+++ b/src/nti/externalization/tests/test_externalization.py
@@ -39,7 +39,7 @@ from ..externalization import toExternalObject
 from ..externalization.standard_fields import get_creator
 from ..interfaces import EXT_REPR_JSON
 from ..interfaces import EXT_REPR_YAML
-from ..interfaces import IExternalObject
+from ..interfaces import IInternalObjectExternalizer as IExternalObject
 from ..interfaces import IExternalObjectDecorator
 from ..interfaces import LocatedExternalDict
 from ..interfaces import LocatedExternalList
@@ -288,7 +288,7 @@ class TestDecorators(CleanUp,
                      unittest.TestCase):
 
     def test_decorate_external_mapping(self):
-        from nti.externalization.interfaces import IExternalMappingDecorator
+        from nti.externalization.interfaces import IExternalStandardDictionaryDecorator
         from nti.externalization.externalization import decorate_external_mapping
         class IRequest(interface.Interface):
             pass
@@ -299,7 +299,7 @@ class TestDecorators(CleanUp,
 
 
         @component.adapter(object)
-        @interface.implementer(IExternalMappingDecorator)
+        @interface.implementer(IExternalStandardDictionaryDecorator)
         class Decorator(object):
 
             def __init__(self, result):
@@ -309,7 +309,7 @@ class TestDecorators(CleanUp,
                 result['decorated'] = True
 
         @component.adapter(object, IRequest)
-        @interface.implementer(IExternalMappingDecorator)
+        @interface.implementer(IExternalStandardDictionaryDecorator)
         class RequestDecorator(object):
             def __init__(self, result, request):
                 pass

--- a/src/nti/externalization/tests/test_representation.py
+++ b/src/nti/externalization/tests/test_representation.py
@@ -296,7 +296,7 @@ class TestJson(AbstractRepresenterTestMixin,
         assert_that(result, is_('{}'))
 
     def test_second_pass(self):
-        from ..interfaces import IExternalObject
+        from ..interfaces import IInternalObjectExternalizer as IExternalObject
         from zope import component
 
         json = self._makeOne()


### PR DESCRIPTION
Update the docs for these. Fixes #117 and fixes #118.

Also be sure that deprecated interface names actually raise deprecation warnings.